### PR TITLE
대회 상태 분할 api 생성

### DIFF
--- a/judger-backend/judger-api/routes/api/v1/contest/index.js
+++ b/judger-backend/judger-api/routes/api/v1/contest/index.js
@@ -11,6 +11,8 @@ router.get('/me', isAuthenticated, controller.getMyContests);
 router.get('/registered', isAuthenticated, controller.getRegisteredContests);
 router.get('/applying', controller.getApplyingContests);
 router.get('/progressing', controller.getProgressingContests);
+router.get('/available', controller.getavailableContests);
+router.get('/ongoing', controller.getongoingContests);
 router.get('/:id', controller.getContest);
 router.get('/:id/problems', isAuthenticated, handleAccessContestProblem, controller.getContestProblems);
 router.get('/confirm/:id', isAuthenticated, controller.confirmPassword);

--- a/judger-frontend/Dockerfile.dev
+++ b/judger-frontend/Dockerfile.dev
@@ -4,7 +4,7 @@ RUN mkdir -p /app
 
 WORKDIR /app
 
-RUN npm i -g -y @angular/cli
+RUN npm i -g -y @angular/cli@11.2.19
 
 COPY ./package*.json /app/
 


### PR DESCRIPTION
대회 상태에 따른 분할 api 생성
get -> /available 현재 신청가능한 대회만 보여줌 (대회 기간 설정이 없다면 대회 시작 전 시간까지, 대회 신청기간 설정시 해당대회 신청 시간에 따라 출력)
get -> /ongoing 지금 진행중인 대회만 보여줌 (신청기간에 상관없이 진행중이라면 보여준다)