### PR TITLE
 검색 기능 활성화

### DIFF
--- a/judger-backend/judger-api/routes/api/v1/notice/controller.js
+++ b/judger-backend/judger-api/routes/api/v1/notice/controller.js
@@ -10,10 +10,27 @@ const { hasRole } = require("../../../../utils/permission");
 
 // 공지사항 여러개
 const getNotices = asyncHandler(async (req, res, next) => {
-   const documents = await Notice.find().populate('writer', 'name role _id');
+   const { query } = req;
+   const result = await Notice.search(query);  
+   const { documents } = result;
 
-   res.json(createResponse(res, documents));
+   // writer 내부에서 필요한 _id, name, role만 남기기
+   const filteredDocuments = documents.map(doc => ({
+      ...doc.toObject(),
+      writer: {
+         _id: doc.writer._id,
+         name: doc.writer.name,
+         role: doc.writer.role
+      }
+   }));
+
+   res.json(createResponse(res, {
+      ...result, 
+      documents: filteredDocuments  
+   }));
 });
+
+
 
 // 단일 공지사항
 const getNotice = asyncHandler(async (req, res, next) => {


### PR DESCRIPTION
기존에 전체 공지사항을 조회할때 사용한 find() 대신 연습문제, 대회등의 검색 방법과 똑같게 search()를 이용하도록 변경(search 안에 검색어를 넣음으로 검색기능 활성화)
이후 작성자의 개인정보 출력을 제한하기 위해 필터링을 한후 다시 추가 
<img width="635" alt="스크린샷 2024-09-06 04 30 50" src="https://github.com/user-attachments/assets/5597ba53-a267-4caa-ace1-56b08dfe17e4">
<img width="650" alt="스크린샷 2024-09-06 04 30 32" src="https://github.com/user-attachments/assets/817d8e24-ba89-4e31-bfee-0d894553db73">
