### PR TITLE
feat: 대회 비밀번호 필수 등록 로직 추가

### DIFF
--- a/judger-frontend/projects/main/src/app/pages/assignment-pages/assignment-detail-page/assignment-detail-page.component.html
+++ b/judger-frontend/projects/main/src/app/pages/assignment-pages/assignment-detail-page/assignment-detail-page.component.html
@@ -3,17 +3,32 @@
   <span class="flex border-bottom pb-2 mobile-column">
     <span class="font-s me-auto">
       과제시간:&nbsp;
-      <span *ngIf="(assignment?.testPeriod | periodRange | async) === -1" class="fw-700">
+      <span
+        *ngIf="(assignment?.testPeriod | periodRange | async) === -1"
+        class="fw-700"
+      >
         {{ assignment | testPeriod }}
-        <span class="text-accent fw-700">({{ assignment.testPeriod.start | restTime | async }} 전)</span>
+        <span class="text-accent fw-700"
+          >({{ assignment.testPeriod.start | restTime | async }} 전)</span
+        >
       </span>
-      <span *ngIf="(assignment?.testPeriod | periodRange | async) === 0" class="text-warn fw-900">
-        <span class="text-warn fw-900">{{ assignment.testPeriod.end | restTime | async }} 남음</span>
+      <span
+        *ngIf="(assignment?.testPeriod | periodRange | async) === 0"
+        class="text-warn fw-900"
+      >
+        <span class="text-warn fw-900"
+          >{{ assignment.testPeriod.end | restTime | async }} 남음</span
+        >
       </span>
-      <span *ngIf="(assignment?.testPeriod | periodRange | async) === 1" class="text-primary"> 종료 </span>
+      <span
+        *ngIf="(assignment?.testPeriod | periodRange | async) === 1"
+        class="text-primary"
+      >
+        종료
+      </span>
     </span>
-    <span class="font-s me-2">과목명: {{assignment?.course}}</span>
-    <span class="font-s">교수명: {{assignment?.writer.name }}</span>
+    <span class="font-s me-2">과목명: {{ assignment?.course }}</span>
+    <span class="font-s">교수명: {{ assignment?.writer.name }}</span>
   </span>
 
   <div class="py-2 border-bottom mb-2">
@@ -21,7 +36,6 @@
   </div>
 
   <div *ngIf="isStudent" class="flex justify-end" style="padding-bottom: 10px">
-
     <button
       mat-flat-button
       color="primary"
@@ -29,24 +43,31 @@
       *ngIf="!isContestant"
       (click)="enroll()"
     >
-      <i class="las la-play"></i><span class="ms-2 mobile-d-none">과제 참여</span>
-    </button>
-
-    <button class="me-2"
-            mat-flat-button color="warn"
-            style="color: white"
-            (click)="unenroll()"
-            *ngIf="isContestant"
-    >
-      <i class="las la-play"></i><span class="ms-2 mobile-d-none">참여 취소</span>
+      <i class="las la-play"></i
+      ><span class="ms-2 mobile-d-none">과제 참여</span>
     </button>
 
     <button
-      mat-flat-button color="accent"
+      class="me-2"
+      mat-flat-button
+      color="warn"
+      style="color: white"
+      (click)="unenroll()"
+      *ngIf="isContestant"
+    >
+      <i class="las la-play"></i
+      ><span class="ms-2 mobile-d-none">참여 취소</span>
+    </button>
+
+    <button
+      mat-flat-button
+      color="accent"
       style="color: white"
       *ngIf="isContestant"
-      [routerLink]="['/assignment', assignment?._id, 'problems']">
-      <i class="las la-play"></i><span class="ms-2 mobile-d-none">문제 페이지</span>
+      [routerLink]="['/assignment', assignment?._id, 'problems']"
+    >
+      <i class="las la-play"></i
+      ><span class="ms-2 mobile-d-none">문제 페이지</span>
     </button>
   </div>
 
@@ -57,14 +78,18 @@
       color="accent"
       [routerLink]="['/assignment/edit', assignment?._id]"
     >
-      <i class="las la-edit"></i><span class="ms-2 mobile-d-none">과제 수정</span>
+      <i class="las la-edit"></i
+      ><span class="ms-2 mobile-d-none">과제 수정</span>
     </button>
 
     <button
       class="text-white me-2"
-      mat-flat-button color="accent"
-      [routerLink]="['/assignment', assignment?._id, 'submits']">
-      <i class="las la-edit"></i><span class="ms-2 mobile-d-none">과제 제출 목록</span>
+      mat-flat-button
+      color="accent"
+      [routerLink]="['/assignment', assignment?._id, 'submits']"
+    >
+      <i class="las la-edit"></i
+      ><span class="ms-2 mobile-d-none">과제 제출 목록</span>
     </button>
 
     <button
@@ -74,11 +99,19 @@
       color="primary"
       [routerLink]="['/assignment', assignment?._id, 'problems']"
     >
-      <i class="las la-folder-plus"></i><span class="ms-2 mobile-d-none">문제 등록/수정</span>
+      <i class="las la-folder-plus"></i
+      ><span class="ms-2 mobile-d-none">문제 관리</span>
     </button>
 
-    <button type="button" class="text-white" (click)="removeAssignment()" mat-flat-button color="warn">
-      <i class="las la-trash-alt"></i><span class="ms-2 mobile-d-none">과제 삭제</span>
+    <button
+      type="button"
+      class="text-white"
+      (click)="removeAssignment()"
+      mat-flat-button
+      color="warn"
+    >
+      <i class="las la-trash-alt"></i
+      ><span class="ms-2 mobile-d-none">과제 삭제</span>
     </button>
   </div>
 </div>

--- a/judger-frontend/projects/main/src/app/pages/contest-pages/contest-detail-page/contest-detail-page.component.html
+++ b/judger-frontend/projects/main/src/app/pages/contest-pages/contest-detail-page/contest-detail-page.component.html
@@ -1,17 +1,34 @@
 <div class="main-container mt-2">
   <h2 class="mb-2 page-title">{{ contest?.title }}</h2>
   <span class="flex border-bottom pb-2 mobile-column">
-    <span class="font-s me-2">참가신청기간: {{ contest | applyingPeriod }}</span>
+    <span class="font-s me-2"
+      >참가신청기간: {{ contest | applyingPeriod }}</span
+    >
     <span class="font-s me-auto">
       대회시간:&nbsp;
-      <span *ngIf="(contest?.testPeriod | periodRange | async) === -1" class="fw-700">
+      <span
+        *ngIf="(contest?.testPeriod | periodRange | async) === -1"
+        class="fw-700"
+      >
         {{ contest | testPeriod }}
-        <span class="text-accent fw-700">({{ contest.testPeriod.start | restTime | async }} 전)</span>
+        <span class="text-accent fw-700"
+          >({{ contest.testPeriod.start | restTime | async }} 전)</span
+        >
       </span>
-      <span *ngIf="(contest?.testPeriod | periodRange | async) === 0" class="text-warn fw-900">
-        <span class="text-warn fw-900">{{ contest.testPeriod.end | restTime | async }} 남음</span>
+      <span
+        *ngIf="(contest?.testPeriod | periodRange | async) === 0"
+        class="text-warn fw-900"
+      >
+        <span class="text-warn fw-900"
+          >{{ contest.testPeriod.end | restTime | async }} 남음</span
+        >
       </span>
-      <span *ngIf="(contest?.testPeriod | periodRange | async) === 1" class="text-primary"> 종료 </span>
+      <span
+        *ngIf="(contest?.testPeriod | periodRange | async) === 1"
+        class="text-primary"
+      >
+        종료
+      </span>
     </span>
     <span class="font-s">작성자: {{ contest?.writer.name }}</span>
   </span>
@@ -20,7 +37,10 @@
     <div class="border-box" [swInnerHtml]="contest?.content"></div>
   </div>
 
-  <div class="flex justify-end" *ngIf="isContestant$ | async; else notContestantTemplate">
+  <div
+    class="flex justify-end"
+    *ngIf="isContestant$ | async; else notContestantTemplate"
+  >
     <a
       *ngIf="isTestPeriod || isAfterTestPeriod"
       class="text-white me-2"
@@ -29,7 +49,8 @@
       routerLink="/scoreboard"
       [queryParams]="{ contest: contest?._id }"
     >
-      <i class="las la-chalkboard"></i><span class="ms-2 mobile-d-none">스코어보드</span>
+      <i class="las la-chalkboard"></i
+      ><span class="ms-2 mobile-d-none">스코어보드</span>
     </a>
     <button
       *ngIf="isBeforeTestPeriod"
@@ -38,7 +59,8 @@
       mat-flat-button
       color="warn"
     >
-      <i class="las la-sign-out-alt"></i><span class="ms-2 mobile-d-none">참가취소</span>
+      <i class="las la-sign-out-alt"></i
+      ><span class="ms-2 mobile-d-none">참가취소</span>
     </button>
     <a
       *ngIf="isTestPeriod"
@@ -47,7 +69,8 @@
       style="color: white"
       [routerLink]="['/contest', contest?._id, 'problems']"
     >
-      <i class="las la-play"></i><span class="ms-2 mobile-d-none">대회시작</span>
+      <i class="las la-play"></i
+      ><span class="ms-2 mobile-d-none">대회시작</span>
     </a>
   </div>
 
@@ -60,13 +83,17 @@
       routerLink="/scoreboard"
       [queryParams]="{ contest: contest?._id }"
     >
-      <i class="las la-chalkboard"></i><span class="ms-2 mobile-d-none">스코어보드</span>
+      <i class="las la-chalkboard"></i
+      ><span class="ms-2 mobile-d-none">스코어보드</span>
     </button>
     <button
       class="text-white me-2"
-      mat-flat-button color="accent"
-      [routerLink]="['/contest', contest?._id, 'submits']">
-      <i class="las la-edit"></i><span class="ms-2 mobile-d-none">대회 제출 목록</span>
+      mat-flat-button
+      color="accent"
+      [routerLink]="['/contest', contest?._id, 'submits']"
+    >
+      <i class="las la-edit"></i
+      ><span class="ms-2 mobile-d-none">대회 제출 목록</span>
     </button>
     <button
       class="text-white me-2"
@@ -74,7 +101,8 @@
       color="accent"
       [routerLink]="['/contest/edit', contest?._id]"
     >
-      <i class="las la-edit"></i><span class="ms-2 mobile-d-none">대회 수정</span>
+      <i class="las la-edit"></i
+      ><span class="ms-2 mobile-d-none">대회 수정</span>
     </button>
     <button
       class="text-white me-2"
@@ -83,7 +111,8 @@
       color="primary"
       [routerLink]="['/contest', contest?._id, 'problems']"
     >
-      <i class="las la-folder-plus"></i><span class="ms-2 mobile-d-none">문제 등록/수정</span>
+      <i class="las la-folder-plus"></i
+      ><span class="ms-2 mobile-d-none">문제 관리</span>
     </button>
     <button
       class="text-white me-2"
@@ -92,10 +121,18 @@
       color="primary"
       [routerLink]="['/contest', contest?._id, 'problems']"
     >
-      <i class="las la-folder-plus"></i><span class="ms-2 mobile-d-none">문제 수정</span>
+      <i class="las la-folder-plus"></i
+      ><span class="ms-2 mobile-d-none">문제 관리</span>
     </button>
-    <button type="button" class="text-white" (click)="removeContest()" mat-flat-button color="warn">
-      <i class="las la-trash-alt"></i><span class="ms-2 mobile-d-none">대회 삭제</span>
+    <button
+      type="button"
+      class="text-white"
+      (click)="removeContest()"
+      mat-flat-button
+      color="warn"
+    >
+      <i class="las la-trash-alt"></i
+      ><span class="ms-2 mobile-d-none">대회 삭제</span>
     </button>
   </div>
 
@@ -107,17 +144,22 @@
         mat-flat-button
         color="primary"
       >
-        <i class="las la-sign-in-alt"></i><span class="ms-2 mobile-d-none">참가신청</span>
+        <i class="las la-sign-in-alt"></i
+        ><span class="ms-2 mobile-d-none">참가신청</span>
       </button>
       <a
-        *ngIf="(isTestPeriod && !(isWriter$ | async)) || (isAfterTestPeriod && !(isWriter$ | async))"
+        *ngIf="
+          (isTestPeriod && !(isWriter$ | async)) ||
+          (isAfterTestPeriod && !(isWriter$ | async))
+        "
         class="text-white"
         mat-flat-button
         color="primary"
         routerLink="/scoreboard"
         [queryParams]="{ contest: contest?._id }"
       >
-        <i class="las la-chalkboard"></i><span class="ms-2 mobile-d-none">스코어보드</span>
+        <i class="las la-chalkboard"></i
+        ><span class="ms-2 mobile-d-none">스코어보드</span>
       </a>
     </div>
   </ng-template>

--- a/judger-frontend/projects/main/src/app/pages/contest-pages/contest-form-page/contest-form-page.component.html
+++ b/judger-frontend/projects/main/src/app/pages/contest-pages/contest-form-page/contest-form-page.component.html
@@ -81,15 +81,13 @@
   </div>
 
   <div class="mb-4">
-    <mat-checkbox color="primary" formControlName="isPassword"
-    >비밀번호 설정</mat-checkbox
-    >
+    <label class="mb-1">비밀번호 설정</label>
     <span class="help block">
       <i class="las la-info-circle me-1"></i>
-      비밀번호를 설정할 경우 문제 열람에 비밀번호 입력이 필요합니다.
+      비밀번호를 설정할 경우 문제 열람 시에 비밀번호 입력이 필요합니다.
     </span>
 
-    <mat-form-field class="w-20 mt-2" *ngIf="isPassword">
+    <mat-form-field class="w-20 mt-2">
       <mat-label>비밀번호</mat-label>
       <input
         matInput
@@ -97,13 +95,10 @@
         formControlName="password"
         placeholder="EX. QWER1234"
       />
+      <mat-error class="error block" *ngIf="hasError('required', 'password')">
+        비밀번호는 필수 입력 항목입니다.
+      </mat-error>
     </mat-form-field>
-
-    <span
-      class="error block relative period-error"
-      *ngIf="hasError('requiredPassword')"
-    >비밀번호를 설정해주세요.</span>
-
   </div>
 
   <div class="flex justify-end">


### PR DESCRIPTION
resolve #15 

## Description

현재 대회 게시글 등록 시에 대회 비밀번호 설정이 선택적으로 이뤄지도록
로직이 구성되어 있는데, 비밀번호를 설정하지 않으면, 대화 문제 관리 페이지 내에서
문제 정보를 정상적으로 로드할 수 없는 이슈가 있어 해당 문제를 없애고자 대회 등록 및 수정
페이지 내에서 비밀번호 입력을 필수로 받도록 관련 로직을 추가하였습니다.

- 추가된 비밀번호 필수 입력 로직 작동 화면

https://github.com/user-attachments/assets/b34bdf27-dff9-4b6e-bcf0-22178cac2f21