### PR TITLE
fix: 스코어보드 생성 오류 해결

### DIFF
--- a/judger-backend/judger-api/kafka/index.js
+++ b/judger-backend/judger-api/kafka/index.js
@@ -16,9 +16,9 @@ const initConsumer = () => {
   consumer.on('message', async (message) => {
     debug(`comsumer message:::${message.value}, consumer partition ::: ${message.partition}`);
     const id = message.value;
-    console.log(`ID ${id} 제출 건 체점 시작`)
+    console.log(`ID ${id} 제출 건 채점 시작`)
     await run(id)
-    console.log(`ID ${id} 제출 건 체점 끝`)
+    console.log(`ID ${id} 제출 건 채점 끝`)
     });
 
   consumer.on('error', error => {

--- a/judger-backend/judger-api/models/@main/schemas/score-board.schema.js
+++ b/judger-backend/judger-api/models/@main/schemas/score-board.schema.js
@@ -42,7 +42,7 @@ const schema = createSchema({
 });
 
 schema.index({ createdAt: -1 });
-schema.index({ parent: 1, user: 1 }, { unique: true });
+schema.index({ contest: 1, user: 1 }, { unique: true });
 
 schema.plugin(searchPlugin({
   mapper: {


### PR DESCRIPTION
<img width="903" alt="스크린샷 2024-11-14 18 49 36" src="https://github.com/user-attachments/assets/e7c24358-083b-4418-a83e-caa498c9778c">
스코어보드 인덱스 기존 parent_1_user_1   -> contest_1_user_1 변경 parent 값은 존재하지 않아 항상 null로 들어가 두번째 스코어보드 생성시 중복이 발생해 스코어보드가 추가적으로 생성되지 않음