### PR TITLE
feat: 문제 일괄 등록 기능 추가

### DIFF
--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/UploadContestProblemsModal.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/UploadContestProblemsModal.tsx
@@ -1,0 +1,100 @@
+import Dropzone from '@/app/components/Dropzone';
+import MyDropzone from '@/app/components/MyDropzone';
+import { IoSetItem, ProblemInfo, RegisterProblemParams } from '@/types/problem';
+import { Modal } from 'flowbite-react';
+import React, { useEffect, useState } from 'react';
+
+interface UploadContestProblemsModalProps {
+  setExcelFileName: React.Dispatch<React.SetStateAction<string>>;
+  setUploadedProblemsInfo: React.Dispatch<
+    React.SetStateAction<RegisterProblemParams[]>
+  >;
+  excelFileUrl: string;
+  setExcelFileUrl: React.Dispatch<React.SetStateAction<string>>;
+  isExcelFileUploadingValidFail: boolean;
+  setIsExcelFileUploadingValidFail: React.Dispatch<
+    React.SetStateAction<boolean>
+  >;
+  openUploadContestProblemsModal: string | undefined;
+  setOpenUploadContestProblemsModal: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+}
+
+export default function UploadContestProblemsModal({
+  setExcelFileName,
+  setUploadedProblemsInfo,
+  excelFileUrl,
+  setExcelFileUrl,
+  isExcelFileUploadingValidFail,
+  setIsExcelFileUploadingValidFail,
+  openUploadContestProblemsModal,
+  setOpenUploadContestProblemsModal,
+}: UploadContestProblemsModalProps) {
+  const [tempUploadedProblemsInfo, setTempUploadedProblemsInfo] = useState<
+    RegisterProblemParams[]
+  >([]);
+
+  useEffect(() => {
+    setIsExcelFileUploadingValidFail(false);
+  }, [setIsExcelFileUploadingValidFail]);
+
+  return (
+    <Modal
+      show={openUploadContestProblemsModal === 'default'}
+      onClose={() => setOpenUploadContestProblemsModal(undefined)}
+      className="modal"
+      size="xl"
+    >
+      <Modal.Body className="flex flex-col gap-y-1 items-start pt-7 pb-0 px-5">
+        <span className="text-[20px] font-semibold">문제 한 번에 등록하기</span>
+
+        <span className="text-[17px] text-[#4e5968] font-medium">
+          엑셀 양식에 문제 정보를 모두 써준 뒤 파일을 올리면 문제를 한 번에
+          등록할 수 있어요.
+        </span>
+
+        <button
+          onClick={() => {
+            window.location.href = '/template/SOJ_대회_문제등록_양식.xlsx';
+          }}
+          className="text-[17px] text-[#007bff] hover:text-[#002fa6] font-medium underline hover:no-underline"
+        >
+          문제 등록 양식 다운받기
+        </button>
+
+        <div className="w-full mt-2 mb-1">
+          <Dropzone
+            type="file"
+            guideMsg="파일을 선택하거나 올려 주세요"
+            guideMsg2="10MB 이하"
+            setExcelFileName={setExcelFileName}
+            setIsFileUploaded={setIsExcelFileUploadingValidFail}
+            isFileUploaded={isExcelFileUploadingValidFail}
+            fileUrl={excelFileUrl}
+            setFileUrl={setExcelFileUrl}
+            setUploadedProblemsInfo={setTempUploadedProblemsInfo}
+          />
+        </div>
+      </Modal.Body>
+      <Modal.Footer className="flex justify-between border-none pt-4">
+        <button
+          onClick={() => setOpenUploadContestProblemsModal(undefined)}
+          className="flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.5rem] rounded-[7px] font-medium focus:bg-[#d3d6da] hover:bg-[#d3d6da]"
+        >
+          닫기
+        </button>
+
+        <button
+          onClick={() => {
+            setUploadedProblemsInfo(tempUploadedProblemsInfo);
+            setOpenUploadContestProblemsModal(undefined);
+          }}
+          className="flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-white bg-[#3a8af9] px-3 py-[0.5rem] rounded-[6px] font-medium  hover:bg-[#1c6cdb]"
+        >
+          등록하기
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/UploadingContestProblemsModal.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/UploadingContestProblemsModal.tsx
@@ -1,0 +1,73 @@
+import Dropzone from '@/app/components/Dropzone';
+import MyDropzone from '@/app/components/MyDropzone';
+import { IoSetItem, ProblemInfo, RegisterProblemParams } from '@/types/problem';
+import { Modal } from 'flowbite-react';
+import React, { useEffect, useState } from 'react';
+
+interface UploadingContestProblemsModalProps {
+  openUploadingContestProblemsModal: string | undefined;
+  setOpenUploadingContestProblemsModal: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+}
+
+export default function UploadingContestProblemsModal({
+  openUploadingContestProblemsModal,
+  setOpenUploadingContestProblemsModal,
+}: UploadingContestProblemsModalProps) {
+  const [tempUploadedProblemsInfo, setTempUploadedProblemsInfo] = useState<
+    RegisterProblemParams[]
+  >([]);
+
+  return (
+    <Modal
+      show={openUploadingContestProblemsModal === 'default'}
+      onClose={() => setOpenUploadingContestProblemsModal(undefined)}
+      className="modal"
+      size="xl"
+    >
+      <Modal.Body className="flex flex-col gap-y-1 items-start pt-7 pb-0 px-5 overflow-hidden">
+        <span className="text-[20px] font-semibold">
+          문제를 등록하는 중이에요
+        </span>
+
+        <span className="text-[17px] text-[#4e5968] font-medium">
+          문제 등록이 완료될 때까지 화면을 닫지 말아주세요.
+        </span>
+
+        <svg
+          viewBox="0 0 100 100"
+          width="110"
+          height="110"
+          className="svg-loading-animation mx-auto h-[10rem]"
+        >
+          <circle
+            fill="none"
+            stroke="#d8d8dc"
+            strokeWidth="9"
+            strokeMiterlimit="10"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            cx="50"
+            cy="50"
+            r="28"
+          ></circle>
+          <circle
+            fill="none"
+            stroke="#477eed"
+            strokeWidth="9"
+            strokeMiterlimit="10"
+            strokeLinecap="round"
+            strokeLinejoin="miter"
+            cx="50"
+            cy="50"
+            r="28"
+            strokeDasharray="226.2"
+            strokeDashoffset="190"
+            className="circle-dash-animation"
+          ></circle>
+        </svg>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/contestProblems/ContestProblemList.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/contestProblems/ContestProblemList.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { ContestInfo } from '@/types/contest';
+import { ProblemInfo } from '@/types/problem';
+import ContestProblemListItem from './ContestProblemListItem';
+
+interface ContestProblemListProps {
+  cid: string;
+  problemsInfo: ProblemInfo[];
+  setProblemsInfo: (problemsInfo: ProblemInfo[]) => void;
+}
+
+export default function ContestProblemList({
+  cid,
+  problemsInfo,
+  setProblemsInfo,
+}: ContestProblemListProps) {
+  return (
+    <div className="mt-3 relative overflow-hidden rounded-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left text-gray-500 ">
+          <thead className="border-y-[1.25px] border-[#d1d6db] text-[15px] uppercase bg-[#f2f4f6] text-center">
+            <tr className="h-[2.75rem]">
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] w-16 px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                번호
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제명
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 실행 시간
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 메모리 사용량
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                점수
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제 파일
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {problemsInfo.length !== 0 && (
+              <>
+                {problemsInfo.map((problemInfo, index) => (
+                  <ContestProblemListItem
+                    problemInfo={problemInfo}
+                    total={problemsInfo.length}
+                    index={index}
+                    key={index}
+                  />
+                ))}
+              </>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/contestProblems/ContestProblemListItem.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/contestProblems/ContestProblemListItem.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { ProblemInfo, IoSetItem, ExampleFile } from '@/types/problem';
+
+interface ContestContestantListItemProps {
+  problemInfo: ProblemInfo;
+  total: number;
+  index: number;
+}
+
+export default function ContestProblemListItem(
+  props: ContestContestantListItemProps,
+) {
+  const { problemInfo, total, index } = props;
+
+  return (
+    <tr className="h-[3rem] border-b-[1.25px] border-[#d1d6db] text-[15px] text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        {index + 1}
+      </th>
+      <td scope="row" className="text-[#4e5968]">
+        {problemInfo.title}
+      </td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxRealTime}</td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxMemory}</td>
+      <td className="text-[#4e5968]">{problemInfo.score}</td>
+      <td>
+        <a
+          target="_blank"
+          href={problemInfo.content}
+          className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+        >
+          보기
+        </a>
+      </td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/contestProblems/EmptyContestProblemListItem.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/contestProblems/EmptyContestProblemListItem.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function EmptyContestContestantListItem() {
+  return (
+    <tr className="h-[2.5rem] border-b-[1.25px] border-[#d1d6db] text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-[#4e5968]">문제 정보가 존재하지 않아요</td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/skeleton/ContestDetailContentLoadingSkeleton.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/skeleton/ContestDetailContentLoadingSkeleton.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+export default function ContestDetailContentLoadingSkeleton() {
+  return (
+    <div className="flex flex-col gap-y-2 pb-5">
+      <div className="flex gap-x-2">
+        <div className="skeleton w-[5rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[7.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[6rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+
+      <div className="mt-4 flex gap-x-2">
+        <div className="skeleton w-[5rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+        <div className="skeleton w-[7.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+        <div className="skeleton w-[5rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+      <div className="flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+      <div className="flex gap-x-2">
+        <div className="skeleton w-[6rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+
+      <div className="mt-4 flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[3rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[5rem] h-[1rem]" />
+      </div>
+
+      <div className="mt-4 flex gap-x-2">
+        <div className="skeleton w-[7.5rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/skeleton/ContestDetailPageLoadingSkeleton.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/skeleton/ContestDetailPageLoadingSkeleton.tsx
@@ -1,0 +1,23 @@
+import ContestDetailContentLoadingSkeleton from './ContestDetailContentLoadingSkeleton';
+
+export default function ContestDetailPageLoadingSkeleton() {
+  return (
+    <div className="mt-6 mb-24 w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col pb-3 border-b border-gray-300">
+        <div className="skeleton w-[30rem] h-[2rem]" />
+        <div className="mt-8 flex justify-between">
+          <div className="flex gap-x-2 h-[1.25rem]">
+            <div className="skeleton w-[17.5rem]" />
+            <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
+            <div className="skeleton w-[20rem]" />
+          </div>
+          <div className="skeleton w-[7.5rem]" />
+        </div>
+      </div>
+
+      <div className="mt-8 border-b">
+        <ContestDetailContentLoadingSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/uploadedProblems/EmptyProblemListItem.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/uploadedProblems/EmptyProblemListItem.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function EmptyProblemListItem() {
+  return (
+    <tr className="h-[2.5rem] border-b-[1.25px] border-[#d1d6db] text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-[#4e5968]">문제 정보가 존재하지 않아요</td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/uploadedProblems/UploadedProblemList.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/uploadedProblems/UploadedProblemList.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { RegisterProblemParams } from '@/types/problem';
+import UploadedProblemListItem from './UploadedProblemListItem';
+
+interface ContestProblemListProps {
+  problemsInfo: RegisterProblemParams[];
+  setUploadedProblemsInfo: React.Dispatch<
+    React.SetStateAction<RegisterProblemParams[]>
+  >;
+}
+
+export default function UploadedProblemList({
+  problemsInfo,
+  setUploadedProblemsInfo,
+}: ContestProblemListProps) {
+  return (
+    <div className="mt-3 relative overflow-hidden rounded-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left text-gray-500 ">
+          <thead className="border-y-[1.25px] border-[#d1d6db] text-[15px] uppercase bg-[#f2f4f6] text-center">
+            <tr className="h-[2.75rem]">
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] w-16 px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                번호
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제명
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 실행 시간
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 메모리 사용량
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                점수
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제 파일
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                입/출력 파일 셋
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                예제 파일
+                <span className="text-[10px] text-[#333d4b] font-normal">
+                  (선택)
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {problemsInfo.length !== 0 && (
+              <>
+                {problemsInfo.map((problemInfo, index) => (
+                  <UploadedProblemListItem
+                    setUploadedProblemsInfo={setUploadedProblemsInfo}
+                    problemInfo={problemInfo}
+                    total={problemsInfo.length}
+                    index={index}
+                    key={index}
+                  />
+                ))}
+              </>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/components/uploadedProblems/UploadedProblemListItem.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/components/uploadedProblems/UploadedProblemListItem.tsx
@@ -1,0 +1,295 @@
+import { ExampleFile, IoSetItem, RegisterProblemParams } from '@/types/problem';
+import { UploadService } from '@/components/utils/uploadService';
+import { useState, useCallback } from 'react';
+import { Accept, useDropzone } from 'react-dropzone';
+
+interface ContestContestantListItemProps {
+  problemInfo: RegisterProblemParams;
+  setUploadedProblemsInfo: React.Dispatch<
+    React.SetStateAction<RegisterProblemParams[]>
+  >;
+  total: number;
+  index: number;
+}
+
+export default function UploadedProblemListItem(
+  props: ContestContestantListItemProps,
+) {
+  const { problemInfo, setUploadedProblemsInfo, index } = props;
+
+  const [uploadService] = useState(new UploadService());
+
+  const getAcceptTypes = (type: string): Accept => {
+    switch (type) {
+      case 'pdf':
+        return { 'application/pdf': ['.pdf'] };
+      case 'in/out':
+        return { 'text/plain': ['.in', '.out'] };
+      case 'exampleFile':
+        return {
+          'application/temp': [
+            '.c',
+            '.cpp',
+            '.java',
+            '.js',
+            '.py',
+            '.kt',
+            '.go',
+          ],
+        };
+      default:
+        return {};
+    }
+  };
+
+  const isMultipleFileAllowed = (fileType: string): boolean => {
+    const multipleFileTypes = ['in/out', 'exampleFile'];
+    return multipleFileTypes.includes(fileType);
+  };
+
+  const openFileContent = async (url: string, filename: string) => {
+    try {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch file: ${response.statusText}`);
+      }
+
+      const text = await response.text();
+
+      const newWindow = window.open('', '_blank');
+      if (newWindow) {
+        newWindow.document.write(`
+          <html>
+            <head>
+              <title>${filename}</title>
+            </head>
+            <body>
+              <pre>${text}</pre>
+            </body>
+          </html>
+        `);
+        newWindow.document.close();
+      } else {
+        console.warn(
+          'Failed to open new window. Please check popup blocker settings.',
+        );
+      }
+    } catch (error) {
+      console.error('Error opening file:', error);
+    }
+  };
+
+  const openUrlsInNewTabs = (items: IoSetItem[] | ExampleFile[]) => {
+    if (items.length === 0) {
+      console.warn('No items to open');
+      return;
+    }
+
+    if ('url' in items[0]) {
+      (items as ExampleFile[]).forEach((file) => {
+        if (file.url) {
+          openFileContent(file.url, file.filename);
+        } else {
+          console.warn('File URL is missing', file);
+        }
+      });
+    } else if ('inFile' in items[0] && 'outFile' in items[0]) {
+      (items as IoSetItem[]).forEach((io) => {
+        openFileContent(io.inFile.url, io.inFile.filename);
+        openFileContent(io.outFile.url, io.outFile.filename);
+      });
+    } else {
+      console.error('Invalid input: Expected ExampleFile or IoSetItem array');
+    }
+  };
+
+  const handleDrop = useCallback(
+    async (acceptedFiles: File[], fileType: string) => {
+      if (acceptedFiles.length === 0) return;
+
+      try {
+        if (fileType === 'in/out') {
+          const fileGroups: { [key: string]: File[] } = {};
+          acceptedFiles.forEach((file) => {
+            const baseName = file.name.replace(/\.(in|out)$/, '');
+            if (!fileGroups[baseName]) {
+              fileGroups[baseName] = [];
+            }
+            fileGroups[baseName].push(file);
+          });
+
+          const ioSetPromises = Object.entries(fileGroups)
+            .filter(
+              ([_, files]) =>
+                files.some((f) => f.name.endsWith('.in')) &&
+                files.some((f) => f.name.endsWith('.out')),
+            )
+            .map(async ([_, files]) => {
+              const inFile = files.find((f) => f.name.endsWith('.in'));
+              const outFile = files.find((f) => f.name.endsWith('.out'));
+
+              if (!inFile || !outFile) return null;
+
+              const inFileResponse = await uploadService.upload(inFile);
+              const outFileResponse = await uploadService.upload(outFile);
+
+              return {
+                inFile: { ...inFileResponse.data, filename: inFile.name },
+                outFile: { ...outFileResponse.data, filename: outFile.name },
+              } as IoSetItem;
+            });
+
+          const validIoSets = (await Promise.all(ioSetPromises)).filter(
+            Boolean,
+          ) as IoSetItem[];
+
+          setUploadedProblemsInfo((prev) => {
+            const updatedProblems = [...prev];
+            const updatedProblem = { ...updatedProblems[index] };
+            updatedProblem.ioSet = [
+              ...(updatedProblem.ioSet || []),
+              ...validIoSets,
+            ];
+            updatedProblems[index] = updatedProblem;
+            return updatedProblems;
+          });
+        } else if (fileType === 'pdf') {
+          const file = acceptedFiles[0];
+          const response = await uploadService.upload(file);
+
+          setUploadedProblemsInfo((prev) => {
+            const updatedProblems = [...prev];
+            const updatedProblem = { ...updatedProblems[index] };
+
+            updatedProblem.content = response.data.url;
+
+            updatedProblems[index] = updatedProblem;
+            return updatedProblems;
+          });
+        } else if (fileType === 'exampleFile') {
+          const exampleFilePromises = acceptedFiles.map(async (file) => {
+            const response = await uploadService.upload(file);
+
+            return {
+              ref: response.data.ref,
+              _id: response.data._id,
+              filename: file.name,
+              url: response.data.url,
+            } as ExampleFile;
+          });
+
+          const uploadedFiles = await Promise.all(exampleFilePromises);
+
+          setUploadedProblemsInfo((prev) => {
+            const updatedProblems = [...prev];
+            const updatedProblem = { ...updatedProblems[index] };
+
+            updatedProblem.exampleFiles = [
+              ...(updatedProblem.exampleFiles || []),
+              ...uploadedFiles,
+            ];
+
+            updatedProblems[index] = updatedProblem;
+            return updatedProblems;
+          });
+        }
+      } catch (error) {
+        console.error(`${fileType} 파일 업로드 실패:`, error);
+      }
+    },
+    [uploadService, setUploadedProblemsInfo, index],
+  );
+
+  // 미리 모든 파일 타입의 Dropzone 설정을 생성
+  const dropzones = {
+    pdf: useDropzone({
+      onDrop: (acceptedFiles) => handleDrop(acceptedFiles, 'pdf'),
+      accept: getAcceptTypes('pdf'),
+      multiple: isMultipleFileAllowed('pdf'),
+    }),
+    inOut: useDropzone({
+      onDrop: (acceptedFiles) => handleDrop(acceptedFiles, 'in/out'),
+      accept: getAcceptTypes('in/out'),
+      multiple: isMultipleFileAllowed('in/out'),
+    }),
+    exampleFile: useDropzone({
+      onDrop: (acceptedFiles) => handleDrop(acceptedFiles, 'exampleFile'),
+      accept: getAcceptTypes('exampleFile'),
+      multiple: isMultipleFileAllowed('exampleFile'),
+    }),
+  };
+
+  return (
+    <tr className="h-[3rem] border-b-[1.25px] border-[#d1d6db] text-[15px] text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        {index + 1}
+      </th>
+      <td scope="row" className="text-[#4e5968]">
+        {problemInfo.title}
+      </td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxRealTime}</td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxMemory}</td>
+      <td className="text-[#4e5968]">{problemInfo.score}</td>
+      <td
+        onClick={() => {
+          ('pdf');
+        }}
+      >
+        {problemInfo.content ? (
+          <a
+            target="_blank"
+            href={problemInfo.content}
+            className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+          >
+            보기
+          </a>
+        ) : (
+          <label
+            {...dropzones.pdf.getRootProps()}
+            className="inline-block text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.4rem] rounded-[6px] font-medium hover:bg-[#d3d6da] cursor-pointer"
+          >
+            등록
+          </label>
+        )}
+      </td>
+      <td>
+        {problemInfo.ioSet.length === 0 ? (
+          <label
+            {...dropzones.inOut.getRootProps()}
+            className="inline-block text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.4rem] rounded-[6px] font-medium hover:bg-[#d3d6da] cursor-pointer"
+          >
+            등록
+          </label>
+        ) : (
+          <button
+            onClick={() => openUrlsInNewTabs(problemInfo.ioSet)}
+            className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+          >
+            보기
+          </button>
+        )}
+      </td>
+      <td>
+        {problemInfo.exampleFiles?.length ? (
+          <button
+            onClick={() => openUrlsInNewTabs(problemInfo.exampleFiles || [])}
+            className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+          >
+            보기
+          </button>
+        ) : (
+          <label
+            {...dropzones.exampleFile.getRootProps()}
+            className="inline-block text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.4rem] rounded-[6px] font-medium hover:bg-[#d3d6da] cursor-pointer"
+          >
+            등록
+          </label>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/contests/[cid]/problems/register/multiple/page.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/register/multiple/page.tsx
@@ -1,0 +1,500 @@
+'use client';
+
+import axiosInstance from '@/utils/axiosInstance';
+import React, { useEffect, useState } from 'react';
+import ContestProblemList from './components/contestProblems/ContestProblemList';
+import {
+  ProblemInfo,
+  ProblemsInfo,
+  RegisterProblemParams,
+} from '@/types/problem';
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import UploadContestProblemsModal from './components/UploadContestProblemsModal';
+import { useDropzone } from 'react-dropzone';
+import * as XLSX from 'xlsx';
+import { UploadService } from '@/components/utils/uploadService';
+import UploadedProblemList from './components/uploadedProblems/UploadedProblemList';
+import { ToastInfoStore } from '@/store/ToastInfo';
+import { useRouter } from 'next/navigation';
+import UploadingContestProblemsModal from './components/UploadingContestProblemsModal';
+import { fetchCurrentUserInfo } from '@/utils/fetchCurrentUserInfo';
+import { UserInfo } from '@/types/user';
+import { userInfoStore } from '@/store/UserInfo';
+import { ContestInfo } from '@/types/contest';
+import Loading from '@/app/components/Loading';
+
+// 대회에 등록된 문제 목록 정보 조회 API
+const fetchContestProblemsDetailInfo = ({ queryKey }: any) => {
+  const cid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/${cid}/problems`,
+  );
+};
+
+// 대회 게시글 정보 조회 API
+const fetchContestDetailInfo = ({ queryKey }: any) => {
+  const cid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/contest/${cid}`,
+  );
+};
+
+interface DefaultProps {
+  params: {
+    cid: string;
+  };
+}
+
+export default function RegisterMultipleContestProblem(props: DefaultProps) {
+  const cid = props.params.cid;
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const addToast = ToastInfoStore((state) => state.addToast);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [excelFileName, setExcelFileName] = useState('');
+  const [excelFileUrl, setExcelFileUrl] = useState('');
+  const [isExcelFileUploadingValidFail, setIsExcelFileUploadingValidFail] =
+    useState(false);
+  const [uploadedProblemsInfo, setUploadedProblemsInfo] = useState<
+    RegisterProblemParams[]
+  >([]);
+  const [problemsInfo, setProblemsInfo] = useState<ProblemInfo[]>([]);
+  const [openUploadContestProblemsModal, setOpenUploadContestProblemsModal] =
+    useState<string | undefined>();
+  const [
+    openUploadingContestProblemsModal,
+    setOpenUploadingContestProblemsModal,
+  ] = useState<string | undefined>();
+
+  const [uploadService] = useState(new UploadService()); // UploadService 인스턴스 생성
+
+  const router = useRouter();
+
+  const queryClient = useQueryClient();
+
+  const results = useQueries({
+    queries: [
+      { queryKey: ['contestDetailInfo', cid], queryFn: fetchContestDetailInfo },
+      {
+        queryKey: ['contestProblemsDetailInfo', cid],
+        queryFn: fetchContestProblemsDetailInfo,
+      },
+    ],
+  });
+
+  const contestInfo: ContestInfo = results[0].data?.data.data;
+  const contestProblemsInfo: ProblemsInfo = results[1].data?.data.data;
+
+  const currentTime = new Date();
+  const contestStartTime = new Date(contestProblemsInfo?.testPeriod.start);
+  const contestEndTime = new Date(contestProblemsInfo?.testPeriod.end);
+
+  useEffect(() => {
+    if (contestProblemsInfo) {
+      setProblemsInfo(contestProblemsInfo.problems);
+    }
+  }, [contestProblemsInfo]);
+
+  const { getRootProps } = useDropzone({
+    onDrop: async (acceptedFiles) => {
+      if (acceptedFiles.length === 0) return;
+
+      const file = acceptedFiles[0];
+      setExcelFileName(file.name);
+
+      // 파일 업로드
+      try {
+        const response = await uploadService.upload(file);
+        const newFile = response.data;
+        setExcelFileUrl(newFile.url); // 업로드된 파일의 URL 설정
+        setIsExcelFileUploadingValidFail(true);
+      } catch (error) {
+        console.error('File upload error:', error);
+        setIsExcelFileUploadingValidFail(false);
+      }
+
+      // 엑셀 데이터 파싱
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const data = new Uint8Array(event.target?.result as ArrayBuffer);
+        const workbook = XLSX.read(data, { type: 'array' });
+
+        // 첫 번째 시트 가져오기
+        const sheetName = workbook.SheetNames[0];
+        const worksheet = workbook.Sheets[sheetName];
+
+        // 시트 데이터를 JSON으로 변환 (4행부터 시작, A–D 열만)
+        const jsonData = XLSX.utils.sheet_to_json(worksheet, {
+          header: ['A', 'B', 'C', 'D'], // 열 이름 지정
+          range: 3, // 4행부터 시작
+        }) as Array<{ A: string; B: number; C: number; D: number }>;
+
+        // RegisterProblemParams 배열로 변환
+        const formattedData: RegisterProblemParams[] = jsonData.map((row) => ({
+          title: row.A || '',
+          content: '',
+          published: null,
+          ioSet: [],
+          options: {
+            maxRealTime: row.B || 0,
+            maxMemory: row.C || 0,
+          },
+          score: row.D || 0,
+        }));
+
+        console.log('Formatted Data:', formattedData);
+
+        // 변환된 데이터 업데이트
+        setUploadedProblemsInfo(formattedData);
+      };
+
+      reader.readAsArrayBuffer(file);
+    },
+    accept: {
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [
+        '.xlsx',
+      ],
+    },
+    multiple: false,
+  });
+
+  const handleBulkRegister = async () => {
+    let hasMissingData = false;
+
+    // 데이터 검증
+    uploadedProblemsInfo.forEach((problem) => {
+      if (!problem.content || !problem.ioSet || problem.ioSet.length === 0) {
+        hasMissingData = true;
+      }
+    });
+
+    if (hasMissingData) {
+      addToast(
+        'warning',
+        '문제 파일 또는 입/출력 파일 셋을 모두 등록해 주세요.',
+      );
+      return;
+    }
+
+    // 모달 창 표시
+    setOpenUploadingContestProblemsModal('default');
+
+    try {
+      let successCount = 0;
+
+      // 등록 요청을 순차적으로 처리
+      for (const problem of uploadedProblemsInfo) {
+        try {
+          await axiosInstance.post(
+            `${process.env.NEXT_PUBLIC_API_VERSION}/problem`,
+            {
+              ...problem,
+              parentType: 'Contest', // 추가 필드
+              parentId: cid, // 필요한 경우 동적으로 설정
+            },
+          );
+
+          // 성공 시 성공 카운트 증가
+          successCount++;
+        } catch (error) {
+          console.error(`문제 "${problem.title}" 등록 중 에러 발생:`, error);
+          addToast('error', `문제 "${problem.title}" 등록 실패.`);
+        }
+
+        // 각 요청 간의 지연 추가 (500ms)
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+
+      // 모든 요청 완료 후
+      setUploadedProblemsInfo([]); // 상태 초기화
+      addToast('success', `문제 ${successCount}개를 등록했어요.`);
+
+      queryClient.invalidateQueries({
+        queryKey: ['contestProblemsDetailInfo'],
+      });
+    } catch (error) {
+      console.error('문제 등록 중 전반적인 에러 발생:', error);
+      addToast('error', '문제 등록 중 전반적인 에러가 발생했습니다.');
+    } finally {
+      // 모달 창 닫기
+      setOpenUploadingContestProblemsModal(undefined);
+    }
+  };
+
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (contestInfo) {
+        const isWriter = contestInfo.writer._id === userInfo._id;
+
+        if (currentTime >= contestStartTime) {
+          addToast('warning', '대회 시작 후에는 등록할 수 없어요.');
+          router.back();
+          return;
+        }
+
+        if (isWriter) {
+          setIsLoading(false);
+          return;
+        }
+
+        addToast('warning', '접근 권한이 없어요.');
+        router.push('/');
+      }
+    });
+  }, [updateUserInfo, contestInfo, router, addToast]);
+
+  if (isLoading) return <Loading />;
+
+  return (
+    <div className="mt-2 px-5 2lg:px-0 overflow-x-auto min-h-[40rem]">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <button
+          onClick={() => {
+            router.push(`/contests/${cid}/problems`);
+          }}
+          className="flex items-center gap-x-1"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="18"
+            viewBox="0 -960 960 960"
+            width="18"
+            fill="#656565"
+          >
+            <path d="M233-440h607q17 0 28.5-11.5T880-480q0-17-11.5-28.5T840-520H233l155-156q11-11 11.5-27.5T388-732q-11-11-28-11t-28 11L108-508q-6 6-8.5 13T97-480q0 8 2.5 15t8.5 13l224 224q11 11 27.5 11t28.5-11q12-12 12-28.5T388-285L233-440Z" />
+          </svg>
+          <span className="text-[#656565] text-xs font-light hover:text-black py-[0.5rem]">
+            뒤로가기
+          </span>
+        </button>
+
+        <div className="h-16 flex justify-between items-center text-[27px] font-semibold tracking-wide overflow-hidden">
+          <span className="lift-up">문제 한 번에 등록</span>
+
+          <div className="flex gap-2">
+            {uploadedProblemsInfo.length !== 0 ? (
+              <>
+                <button
+                  onClick={() => {
+                    setOpenUploadContestProblemsModal('default');
+                  }}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#f2f4f6] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#d3d6da]"
+                >
+                  <span
+                    aria-hidden="false"
+                    role="presentation"
+                    style={{
+                      height: '18px',
+                      width: '18px',
+                      minWidth: '18px',
+                      padding: '0px',
+                    }}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <path
+                        fill="#8d95a0"
+                        d="M12.766 6.604a1.108 1.108 0 00-1.198-.237 1.113 1.113 0 00-.358.237L5.504 12.31a1.1 1.1 0 001.555 1.556l3.829-3.83v11.345a1.1 1.1 0 002.2 0V10.038l3.829 3.829c.215.215.496.322.778.322a1.1 1.1 0 00.778-1.878l-5.707-5.707zM21.38 2.1H2.596a1.1 1.1 0 000 2.2h18.785a1.1 1.1 0 100-2.2"
+                        fillRule="evenodd"
+                      ></path>
+                    </svg>
+                  </span>
+                  <span className="text-[#4e5968] whitespace-nowrap">
+                    파일 다시 올리기
+                  </span>
+                </button>
+
+                <button
+                  onClick={handleBulkRegister}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#3183f6] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#1c6cdb]"
+                >
+                  <span className="text-white whitespace-nowrap">
+                    {uploadedProblemsInfo.length}개 문제 등록하기
+                  </span>
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  onClick={() => {
+                    window.location.href =
+                      '/template/SOJ_대회_문제등록_양식.xlsx';
+                  }}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#e8f3ff] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#cee1fc]"
+                >
+                  <span
+                    aria-hidden="false"
+                    role="presentation"
+                    style={{
+                      height: '18px',
+                      width: '18px',
+                      minWidth: '18px',
+                      padding: '0px',
+                    }}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <g fill="#487fee">
+                        <path d="M11.2 17.7c.1.1.2.2.4.2.3.1.6.1.8 0 .1-.1.3-.1.4-.2l5.7-5.7c.4-.4.4-1.1 0-1.6s-1.1-.4-1.6 0l-3.8 3.8V2.9c0-.6-.5-1.1-1.1-1.1s-1.1.5-1.1 1.1v11.3l-3.8-3.8c-.2-.2-.5-.3-.8-.3s-.6.1-.8.3c-.4.4-.4 1.1 0 1.6l5.7 5.7zM2.6 22.2h18.8c.6 0 1.1-.5 1.1-1.1S22 20 21.4 20H2.6c-.6 0-1.1.5-1.1 1.1s.5 1.1 1.1 1.1z"></path>
+                      </g>
+                    </svg>
+                  </span>
+                  <span className="text-[#1b64da] whitespace-nowrap">
+                    문제 등록 양식 다운받기
+                  </span>
+                </button>
+
+                <button
+                  onClick={() => setOpenUploadContestProblemsModal('default')}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#3183f6] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#1c6cdb]"
+                >
+                  <span
+                    aria-hidden="false"
+                    role="presentation"
+                    style={{
+                      height: '18px',
+                      width: '18px',
+                      minWidth: '18px',
+                      padding: '0px',
+                    }}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <path
+                        fill="white"
+                        d="M12.766 6.604a1.108 1.108 0 00-1.198-.237 1.113 1.113 0 00-.358.237L5.504 12.31a1.1 1.1 0 001.555 1.556l3.829-3.83v11.345a1.1 1.1 0 002.2 0V10.038l3.829 3.829c.215.215.496.322.778.322a1.1 1.1 0 00.778-1.878l-5.707-5.707zM21.38 2.1H2.596a1.1 1.1 0 000 2.2h18.785a1.1 1.1 0 100-2.2"
+                        fillRule="evenodd"
+                      ></path>
+                    </svg>
+                  </span>
+                  <span className="text-white whitespace-nowrap">
+                    문제 한 번에 등록하기
+                  </span>
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {uploadedProblemsInfo.length !== 0 ? (
+          <div>
+            <label
+              {...getRootProps()}
+              className="mt-4 flex justify-between items-center pl-4 pr-2 py-[0.4rem] bg-white border-none outline outline-1 outline-[#e6e8ea] hover:outline-2 hover:outline-[#a3c6fa] hover:outline-offset-[-1px] rounded-[7px] duration-100"
+            >
+              <div className="flex items-center gap-x-2">
+                <span
+                  className="icon p-icon p-menu__item__addon"
+                  aria-hidden="false"
+                  role="presentation"
+                >
+                  <svg
+                    height="20"
+                    width="20"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <mask id="a" fill="#fff">
+                      <path
+                        d="m0 0h20v19.9996h-20z"
+                        fill="#fff"
+                        fillRule="evenodd"
+                      ></path>
+                    </mask>
+                    <g
+                      fill="#26a06b"
+                      fillRule="evenodd"
+                      transform="translate(2 2)"
+                    >
+                      <path d="m13 14.1719v5.828l7-7h-5.828c-.649 0-1.162.523-1.162 1.162"></path>
+                      <path
+                        d="m5.918 5.6036 1.971 2.893c.061.381-.228.489-.559.489h-.746c-.321-.016-.379-.033-.585-.4l-1.016-1.865-.013-.015-.013.015-1.016 1.865c-.206.367-.264.384-.585.4h-.746c-.331 0-.62-.108-.559-.489l1.971-2.893.001-.001-.038-.044-1.9-2.82c-.15-.217.122-.517.502-.517h.746c.331 0 .372.043.538.315l1.084 1.926.015.018.015-.018 1.084-1.926c.166-.272.207-.315.538-.315h.746c.38 0 .652.3.503.517l-1.901 2.82-.038.044zm12.9-5.604h-17.636c-.654 0-1.182.528-1.182 1.182v17.647c0 .654.528 1.171 1.172 1.171h10.005v-5.878c0-1.626 1.319-2.945 2.944-2.945h5.879v-9.995c0-.654-.528-1.182-1.182-1.182z"
+                        mask="url(#a)"
+                      ></path>
+                    </g>
+                  </svg>
+                </span>
+
+                <span className="text-[15px] text-[#4e5968]">
+                  {excelFileName}
+                </span>
+              </div>
+
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setUploadedProblemsInfo([]);
+                }}
+                className="flex justify-center items-center gap-[0.375rem] text-[13px] text-[#4e5968] bg-[#f2f4f6] px-3 py-1 rounded-[6px] font-light focus:bg-[#d3d6da] hover:bg-[#e6e8ea]"
+              >
+                삭제
+              </button>
+            </label>
+
+            <div className="mt-10">
+              <div className="flex items-center gap-x-[0.6rem] mb-3">
+                <span className="font-semibold text-[19px] text-[#333d4b]">
+                  등록될 문제
+                </span>
+                <span className="text-[#6d7683] text-[0.825rem] font-light">
+                  {uploadedProblemsInfo.length}개
+                </span>
+              </div>
+
+              <UploadedProblemList
+                problemsInfo={uploadedProblemsInfo}
+                setUploadedProblemsInfo={setUploadedProblemsInfo}
+              />
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="py-2">
+              <div className="flex mt-4 justify-between items-center">
+                <span className="text-[#6d7683] text-[0.825rem] font-light">
+                  총{' '}
+                  <span className="text-[#6d7683]">{problemsInfo.length}</span>
+                  개
+                </span>
+              </div>
+
+              <ContestProblemList
+                cid={cid}
+                problemsInfo={problemsInfo}
+                setProblemsInfo={setProblemsInfo}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      {openUploadingContestProblemsModal && (
+        <UploadingContestProblemsModal
+          openUploadingContestProblemsModal={openUploadingContestProblemsModal}
+          setOpenUploadingContestProblemsModal={
+            setOpenUploadingContestProblemsModal
+          }
+        />
+      )}
+
+      {openUploadContestProblemsModal && (
+        <UploadContestProblemsModal
+          setExcelFileName={setExcelFileName}
+          setUploadedProblemsInfo={setUploadedProblemsInfo}
+          excelFileUrl={excelFileUrl}
+          setExcelFileUrl={setExcelFileUrl}
+          isExcelFileUploadingValidFail={isExcelFileUploadingValidFail}
+          setIsExcelFileUploadingValidFail={setIsExcelFileUploadingValidFail}
+          openUploadContestProblemsModal={openUploadContestProblemsModal}
+          setOpenUploadContestProblemsModal={setOpenUploadContestProblemsModal}
+        />
+      )}
+    </div>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/UploadExamProblemsModal.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/UploadExamProblemsModal.tsx
@@ -1,0 +1,99 @@
+import Dropzone from '@/app/components/Dropzone';
+import { RegisterProblemParams } from '@/types/problem';
+import { Modal } from 'flowbite-react';
+import React, { useEffect, useState } from 'react';
+
+interface UploadExamProblemsModalProps {
+  setExcelFileName: React.Dispatch<React.SetStateAction<string>>;
+  setUploadedProblemsInfo: React.Dispatch<
+    React.SetStateAction<RegisterProblemParams[]>
+  >;
+  excelFileUrl: string;
+  setExcelFileUrl: React.Dispatch<React.SetStateAction<string>>;
+  isExcelFileUploadingValidFail: boolean;
+  setIsExcelFileUploadingValidFail: React.Dispatch<
+    React.SetStateAction<boolean>
+  >;
+  openUploadExamProblemsModal: string | undefined;
+  setOpenUploadExamProblemsModal: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+}
+
+export default function UploadExamProblemsModal({
+  setExcelFileName,
+  setUploadedProblemsInfo,
+  excelFileUrl,
+  setExcelFileUrl,
+  isExcelFileUploadingValidFail,
+  setIsExcelFileUploadingValidFail,
+  openUploadExamProblemsModal,
+  setOpenUploadExamProblemsModal,
+}: UploadExamProblemsModalProps) {
+  const [tempUploadedProblemsInfo, setTempUploadedProblemsInfo] = useState<
+    RegisterProblemParams[]
+  >([]);
+
+  useEffect(() => {
+    setIsExcelFileUploadingValidFail(false);
+  }, [setIsExcelFileUploadingValidFail]);
+
+  return (
+    <Modal
+      show={openUploadExamProblemsModal === 'default'}
+      onClose={() => setOpenUploadExamProblemsModal(undefined)}
+      className="modal"
+      size="xl"
+    >
+      <Modal.Body className="flex flex-col gap-y-1 items-start pt-7 pb-0 px-5">
+        <span className="text-[20px] font-semibold">문제 한 번에 등록하기</span>
+
+        <span className="text-[17px] text-[#4e5968] font-medium">
+          엑셀 양식에 문제 정보를 모두 써준 뒤 파일을 올리면 문제를 한 번에
+          등록할 수 있어요.
+        </span>
+
+        <button
+          onClick={() => {
+            window.location.href = '/template/SOJ_시험_문제등록_양식.xlsx';
+          }}
+          className="text-[17px] text-[#007bff] hover:text-[#002fa6] font-medium underline hover:no-underline"
+        >
+          문제 등록 양식 다운받기
+        </button>
+
+        <div className="w-full mt-2 mb-1">
+          <Dropzone
+            type="file"
+            guideMsg="파일을 선택하거나 올려 주세요"
+            guideMsg2="10MB 이하"
+            setExcelFileName={setExcelFileName}
+            setIsFileUploaded={setIsExcelFileUploadingValidFail}
+            isFileUploaded={isExcelFileUploadingValidFail}
+            fileUrl={excelFileUrl}
+            setFileUrl={setExcelFileUrl}
+            setUploadedProblemsInfo={setTempUploadedProblemsInfo}
+          />
+        </div>
+      </Modal.Body>
+      <Modal.Footer className="flex justify-between border-none pt-4">
+        <button
+          onClick={() => setOpenUploadExamProblemsModal(undefined)}
+          className="flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.5rem] rounded-[7px] font-medium focus:bg-[#d3d6da] hover:bg-[#d3d6da]"
+        >
+          닫기
+        </button>
+
+        <button
+          onClick={() => {
+            setUploadedProblemsInfo(tempUploadedProblemsInfo);
+            setOpenUploadExamProblemsModal(undefined);
+          }}
+          className="flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-white bg-[#3a8af9] px-3 py-[0.5rem] rounded-[6px] font-medium  hover:bg-[#1c6cdb]"
+        >
+          등록하기
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/UploadingExamProblemsModal.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/UploadingExamProblemsModal.tsx
@@ -1,0 +1,71 @@
+import { RegisterProblemParams } from '@/types/problem';
+import { Modal } from 'flowbite-react';
+import React, { useState } from 'react';
+
+interface UploadingExamProblemsModalProps {
+  openUploadingExamProblemsModal: string | undefined;
+  setOpenUploadingExamProblemsModal: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+}
+
+export default function UploadingExamProblemsModal({
+  openUploadingExamProblemsModal,
+  setOpenUploadingExamProblemsModal,
+}: UploadingExamProblemsModalProps) {
+  const [tempUploadedProblemsInfo, setTempUploadedProblemsInfo] = useState<
+    RegisterProblemParams[]
+  >([]);
+
+  return (
+    <Modal
+      show={openUploadingExamProblemsModal === 'default'}
+      onClose={() => setOpenUploadingExamProblemsModal(undefined)}
+      className="modal"
+      size="xl"
+    >
+      <Modal.Body className="flex flex-col gap-y-1 items-start pt-7 pb-0 px-5 overflow-hidden">
+        <span className="text-[20px] font-semibold">
+          문제를 등록하는 중이에요
+        </span>
+
+        <span className="text-[17px] text-[#4e5968] font-medium">
+          문제 등록이 완료될 때까지 화면을 닫지 말아주세요.
+        </span>
+
+        <svg
+          viewBox="0 0 100 100"
+          width="110"
+          height="110"
+          className="svg-loading-animation mx-auto h-[10rem]"
+        >
+          <circle
+            fill="none"
+            stroke="#d8d8dc"
+            strokeWidth="9"
+            strokeMiterlimit="10"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            cx="50"
+            cy="50"
+            r="28"
+          ></circle>
+          <circle
+            fill="none"
+            stroke="#477eed"
+            strokeWidth="9"
+            strokeMiterlimit="10"
+            strokeLinecap="round"
+            strokeLinejoin="miter"
+            cx="50"
+            cy="50"
+            r="28"
+            strokeDasharray="226.2"
+            strokeDashoffset="190"
+            className="circle-dash-animation"
+          ></circle>
+        </svg>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/examProblems/EmptyExamProblemListItem.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/examProblems/EmptyExamProblemListItem.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function EmptyExamProblemListItem() {
+  return (
+    <tr className="h-[2.5rem] border-b-[1.25px] border-[#d1d6db] text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-[#4e5968]">문제 정보가 존재하지 않아요</td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/examProblems/ExamProblemList.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/examProblems/ExamProblemList.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { ProblemInfo } from '@/types/problem';
+import ExamProblemListItem from './ExamProblemListItem';
+
+interface ExamProblemListProps {
+  eid: string;
+  problemsInfo: ProblemInfo[];
+  setProblemsInfo: (problemsInfo: ProblemInfo[]) => void;
+}
+
+export default function ExamProblemList({
+  eid,
+  problemsInfo,
+  setProblemsInfo,
+}: ExamProblemListProps) {
+  return (
+    <div className="mt-3 relative overflow-hidden rounded-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left text-gray-500 ">
+          <thead className="border-y-[1.25px] border-[#d1d6db] text-[15px] uppercase bg-[#f2f4f6] text-center">
+            <tr className="h-[2.75rem]">
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] w-16 px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                번호
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제명
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 실행 시간
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 메모리 사용량
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                점수
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제 파일
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {problemsInfo.length !== 0 && (
+              <>
+                {problemsInfo.map((problemInfo, index) => (
+                  <ExamProblemListItem
+                    problemInfo={problemInfo}
+                    total={problemsInfo.length}
+                    index={index}
+                    key={index}
+                  />
+                ))}
+              </>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/examProblems/ExamProblemListItem.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/examProblems/ExamProblemListItem.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ProblemInfo, IoSetItem, ExampleFile } from '@/types/problem';
+
+interface ExamProblemListItemProps {
+  problemInfo: ProblemInfo;
+  total: number;
+  index: number;
+}
+
+export default function ExamProblemListItem(props: ExamProblemListItemProps) {
+  const { problemInfo, total, index } = props;
+
+  return (
+    <tr className="h-[3rem] border-b-[1.25px] border-[#d1d6db] text-[15px] text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        {index + 1}
+      </th>
+      <td scope="row" className="text-[#4e5968]">
+        {problemInfo.title}
+      </td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxRealTime}</td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxMemory}</td>
+      <td className="text-[#4e5968]">{problemInfo.score}</td>
+      <td>
+        <a
+          target="_blank"
+          href={problemInfo.content}
+          className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+        >
+          보기
+        </a>
+      </td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/skeleton/ExamDetailContentLoadingSkeleton.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/skeleton/ExamDetailContentLoadingSkeleton.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+export default function ExamDetailContentLoadingSkeleton() {
+  return (
+    <div className="flex flex-col gap-y-2 pb-5">
+      <div className="flex gap-x-2">
+        <div className="skeleton w-[5rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[7.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[6rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+
+      <div className="mt-4 flex gap-x-2">
+        <div className="skeleton w-[5rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+        <div className="skeleton w-[7.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+        <div className="skeleton w-[5rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+      <div className="flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+      <div className="flex gap-x-2">
+        <div className="skeleton w-[6rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+
+      <div className="mt-4 flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[3rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[5rem] h-[1rem]" />
+      </div>
+
+      <div className="mt-4 flex gap-x-2">
+        <div className="skeleton w-[7.5rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/skeleton/ExamDetailPageLoadingSkeleton.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/skeleton/ExamDetailPageLoadingSkeleton.tsx
@@ -1,0 +1,23 @@
+import ExamDetailContentLoadingSkeleton from './ExamDetailContentLoadingSkeleton';
+
+export default function ExamDetailPageLoadingSkeleton() {
+  return (
+    <div className="mt-6 mb-24 w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col pb-3 border-b border-gray-300">
+        <div className="skeleton w-[30rem] h-[2rem]" />
+        <div className="mt-8 flex justify-between">
+          <div className="flex gap-x-2 h-[1.25rem]">
+            <div className="skeleton w-[17.5rem]" />
+            <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
+            <div className="skeleton w-[20rem]" />
+          </div>
+          <div className="skeleton w-[7.5rem]" />
+        </div>
+      </div>
+
+      <div className="mt-8 border-b">
+        <ExamDetailContentLoadingSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/uploadedProblems/EmptyProblemListItem.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/uploadedProblems/EmptyProblemListItem.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function EmptyProblemListItem() {
+  return (
+    <tr className="h-[2.5rem] border-b-[1.25px] border-[#d1d6db] text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-[#4e5968]">문제 정보가 존재하지 않아요</td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/uploadedProblems/UploadedProblemList.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/uploadedProblems/UploadedProblemList.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { RegisterProblemParams } from '@/types/problem';
+import UploadedProblemListItem from './UploadedProblemListItem';
+
+interface ContestProblemListProps {
+  problemsInfo: RegisterProblemParams[];
+  setUploadedProblemsInfo: React.Dispatch<
+    React.SetStateAction<RegisterProblemParams[]>
+  >;
+}
+
+export default function UploadedProblemList({
+  problemsInfo,
+  setUploadedProblemsInfo,
+}: ContestProblemListProps) {
+  return (
+    <div className="mt-3 relative overflow-hidden rounded-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left text-gray-500 ">
+          <thead className="border-y-[1.25px] border-[#d1d6db] text-[15px] uppercase bg-[#f2f4f6] text-center">
+            <tr className="h-[2.75rem]">
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] w-16 px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                번호
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제명
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 실행 시간
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 메모리 사용량
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                점수
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제 파일
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                입/출력 파일 셋
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                예제 파일
+                <span className="text-[10px] text-[#333d4b] font-normal">
+                  (선택)
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {problemsInfo.length !== 0 && (
+              <>
+                {problemsInfo.map((problemInfo, index) => (
+                  <UploadedProblemListItem
+                    setUploadedProblemsInfo={setUploadedProblemsInfo}
+                    problemInfo={problemInfo}
+                    total={problemsInfo.length}
+                    index={index}
+                    key={index}
+                  />
+                ))}
+              </>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/components/uploadedProblems/UploadedProblemListItem.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/components/uploadedProblems/UploadedProblemListItem.tsx
@@ -1,0 +1,295 @@
+import { ExampleFile, IoSetItem, RegisterProblemParams } from '@/types/problem';
+import { UploadService } from '@/components/utils/uploadService';
+import { useState, useCallback } from 'react';
+import { Accept, useDropzone } from 'react-dropzone';
+
+interface ContestContestantListItemProps {
+  problemInfo: RegisterProblemParams;
+  setUploadedProblemsInfo: React.Dispatch<
+    React.SetStateAction<RegisterProblemParams[]>
+  >;
+  total: number;
+  index: number;
+}
+
+export default function UploadedProblemListItem(
+  props: ContestContestantListItemProps,
+) {
+  const { problemInfo, setUploadedProblemsInfo, index } = props;
+
+  const [uploadService] = useState(new UploadService());
+
+  const getAcceptTypes = (type: string): Accept => {
+    switch (type) {
+      case 'pdf':
+        return { 'application/pdf': ['.pdf'] };
+      case 'in/out':
+        return { 'text/plain': ['.in', '.out'] };
+      case 'exampleFile':
+        return {
+          'application/temp': [
+            '.c',
+            '.cpp',
+            '.java',
+            '.js',
+            '.py',
+            '.kt',
+            '.go',
+          ],
+        };
+      default:
+        return {};
+    }
+  };
+
+  const isMultipleFileAllowed = (fileType: string): boolean => {
+    const multipleFileTypes = ['in/out', 'exampleFile'];
+    return multipleFileTypes.includes(fileType);
+  };
+
+  const openFileContent = async (url: string, filename: string) => {
+    try {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch file: ${response.statusText}`);
+      }
+
+      const text = await response.text();
+
+      const newWindow = window.open('', '_blank');
+      if (newWindow) {
+        newWindow.document.write(`
+          <html>
+            <head>
+              <title>${filename}</title>
+            </head>
+            <body>
+              <pre>${text}</pre>
+            </body>
+          </html>
+        `);
+        newWindow.document.close();
+      } else {
+        console.warn(
+          'Failed to open new window. Please check popup blocker settings.',
+        );
+      }
+    } catch (error) {
+      console.error('Error opening file:', error);
+    }
+  };
+
+  const openUrlsInNewTabs = (items: IoSetItem[] | ExampleFile[]) => {
+    if (items.length === 0) {
+      console.warn('No items to open');
+      return;
+    }
+
+    if ('url' in items[0]) {
+      (items as ExampleFile[]).forEach((file) => {
+        if (file.url) {
+          openFileContent(file.url, file.filename);
+        } else {
+          console.warn('File URL is missing', file);
+        }
+      });
+    } else if ('inFile' in items[0] && 'outFile' in items[0]) {
+      (items as IoSetItem[]).forEach((io) => {
+        openFileContent(io.inFile.url, io.inFile.filename);
+        openFileContent(io.outFile.url, io.outFile.filename);
+      });
+    } else {
+      console.error('Invalid input: Expected ExampleFile or IoSetItem array');
+    }
+  };
+
+  const handleDrop = useCallback(
+    async (acceptedFiles: File[], fileType: string) => {
+      if (acceptedFiles.length === 0) return;
+
+      try {
+        if (fileType === 'in/out') {
+          const fileGroups: { [key: string]: File[] } = {};
+          acceptedFiles.forEach((file) => {
+            const baseName = file.name.replace(/\.(in|out)$/, '');
+            if (!fileGroups[baseName]) {
+              fileGroups[baseName] = [];
+            }
+            fileGroups[baseName].push(file);
+          });
+
+          const ioSetPromises = Object.entries(fileGroups)
+            .filter(
+              ([_, files]) =>
+                files.some((f) => f.name.endsWith('.in')) &&
+                files.some((f) => f.name.endsWith('.out')),
+            )
+            .map(async ([_, files]) => {
+              const inFile = files.find((f) => f.name.endsWith('.in'));
+              const outFile = files.find((f) => f.name.endsWith('.out'));
+
+              if (!inFile || !outFile) return null;
+
+              const inFileResponse = await uploadService.upload(inFile);
+              const outFileResponse = await uploadService.upload(outFile);
+
+              return {
+                inFile: { ...inFileResponse.data, filename: inFile.name },
+                outFile: { ...outFileResponse.data, filename: outFile.name },
+              } as IoSetItem;
+            });
+
+          const validIoSets = (await Promise.all(ioSetPromises)).filter(
+            Boolean,
+          ) as IoSetItem[];
+
+          setUploadedProblemsInfo((prev) => {
+            const updatedProblems = [...prev];
+            const updatedProblem = { ...updatedProblems[index] };
+            updatedProblem.ioSet = [
+              ...(updatedProblem.ioSet || []),
+              ...validIoSets,
+            ];
+            updatedProblems[index] = updatedProblem;
+            return updatedProblems;
+          });
+        } else if (fileType === 'pdf') {
+          const file = acceptedFiles[0];
+          const response = await uploadService.upload(file);
+
+          setUploadedProblemsInfo((prev) => {
+            const updatedProblems = [...prev];
+            const updatedProblem = { ...updatedProblems[index] };
+
+            updatedProblem.content = response.data.url;
+
+            updatedProblems[index] = updatedProblem;
+            return updatedProblems;
+          });
+        } else if (fileType === 'exampleFile') {
+          const exampleFilePromises = acceptedFiles.map(async (file) => {
+            const response = await uploadService.upload(file);
+
+            return {
+              ref: response.data.ref,
+              _id: response.data._id,
+              filename: file.name,
+              url: response.data.url,
+            } as ExampleFile;
+          });
+
+          const uploadedFiles = await Promise.all(exampleFilePromises);
+
+          setUploadedProblemsInfo((prev) => {
+            const updatedProblems = [...prev];
+            const updatedProblem = { ...updatedProblems[index] };
+
+            updatedProblem.exampleFiles = [
+              ...(updatedProblem.exampleFiles || []),
+              ...uploadedFiles,
+            ];
+
+            updatedProblems[index] = updatedProblem;
+            return updatedProblems;
+          });
+        }
+      } catch (error) {
+        console.error(`${fileType} 파일 업로드 실패:`, error);
+      }
+    },
+    [uploadService, setUploadedProblemsInfo, index],
+  );
+
+  // 미리 모든 파일 타입의 Dropzone 설정을 생성
+  const dropzones = {
+    pdf: useDropzone({
+      onDrop: (acceptedFiles) => handleDrop(acceptedFiles, 'pdf'),
+      accept: getAcceptTypes('pdf'),
+      multiple: isMultipleFileAllowed('pdf'),
+    }),
+    inOut: useDropzone({
+      onDrop: (acceptedFiles) => handleDrop(acceptedFiles, 'in/out'),
+      accept: getAcceptTypes('in/out'),
+      multiple: isMultipleFileAllowed('in/out'),
+    }),
+    exampleFile: useDropzone({
+      onDrop: (acceptedFiles) => handleDrop(acceptedFiles, 'exampleFile'),
+      accept: getAcceptTypes('exampleFile'),
+      multiple: isMultipleFileAllowed('exampleFile'),
+    }),
+  };
+
+  return (
+    <tr className="h-[3rem] border-b-[1.25px] border-[#d1d6db] text-[15px] text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        {index + 1}
+      </th>
+      <td scope="row" className="text-[#4e5968]">
+        {problemInfo.title}
+      </td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxRealTime}</td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxMemory}</td>
+      <td className="text-[#4e5968]">{problemInfo.score}</td>
+      <td
+        onClick={() => {
+          ('pdf');
+        }}
+      >
+        {problemInfo.content ? (
+          <a
+            target="_blank"
+            href={problemInfo.content}
+            className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+          >
+            보기
+          </a>
+        ) : (
+          <label
+            {...dropzones.pdf.getRootProps()}
+            className="inline-block text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.4rem] rounded-[6px] font-medium hover:bg-[#d3d6da] cursor-pointer"
+          >
+            등록
+          </label>
+        )}
+      </td>
+      <td>
+        {problemInfo.ioSet.length === 0 ? (
+          <label
+            {...dropzones.inOut.getRootProps()}
+            className="inline-block text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.4rem] rounded-[6px] font-medium hover:bg-[#d3d6da] cursor-pointer"
+          >
+            등록
+          </label>
+        ) : (
+          <button
+            onClick={() => openUrlsInNewTabs(problemInfo.ioSet)}
+            className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+          >
+            보기
+          </button>
+        )}
+      </td>
+      <td>
+        {problemInfo.exampleFiles?.length ? (
+          <button
+            onClick={() => openUrlsInNewTabs(problemInfo.exampleFiles || [])}
+            className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+          >
+            보기
+          </button>
+        ) : (
+          <label
+            {...dropzones.exampleFile.getRootProps()}
+            className="inline-block text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.4rem] rounded-[6px] font-medium hover:bg-[#d3d6da] cursor-pointer"
+          >
+            등록
+          </label>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/exams/[eid]/problems/register/multiple/page.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/register/multiple/page.tsx
@@ -1,0 +1,499 @@
+'use client';
+
+import axiosInstance from '@/utils/axiosInstance';
+import React, { useEffect, useState } from 'react';
+import {
+  ProblemInfo,
+  ProblemsInfo,
+  RegisterProblemParams,
+} from '@/types/problem';
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import UploadExamProblemsModal from './components/UploadExamProblemsModal';
+import { useDropzone } from 'react-dropzone';
+import * as XLSX from 'xlsx';
+import { UploadService } from '@/components/utils/uploadService';
+import UploadedProblemList from './components/uploadedProblems/UploadedProblemList';
+import { ToastInfoStore } from '@/store/ToastInfo';
+import { useRouter } from 'next/navigation';
+import { fetchCurrentUserInfo } from '@/utils/fetchCurrentUserInfo';
+import { UserInfo } from '@/types/user';
+import { userInfoStore } from '@/store/UserInfo';
+import Loading from '@/app/components/Loading';
+import { ExamInfo } from '@/types/exam';
+import ExamProblemList from './components/examProblems/ExamProblemList';
+import UploadingExamProblemsModal from './components/UploadingExamProblemsModal';
+
+// 시험에 등록된 문제 목록 정보 조회 API
+const fetchExamProblemsDetailInfo = ({ queryKey }: any) => {
+  const eid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/${eid}/problems`,
+  );
+};
+// 시험 게시글 정보 조회 API
+const fetchExamDetailInfo = ({ queryKey }: any) => {
+  const eid = queryKey[1];
+  return axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/${eid}`,
+  );
+};
+
+interface DefaultProps {
+  params: {
+    eid: string;
+  };
+}
+
+export default function RegisterMultipleExamProblem(props: DefaultProps) {
+  const eid = props.params.eid;
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const addToast = ToastInfoStore((state) => state.addToast);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [excelFileName, setExcelFileName] = useState('');
+  const [excelFileUrl, setExcelFileUrl] = useState('');
+  const [isExcelFileUploadingValidFail, setIsExcelFileUploadingValidFail] =
+    useState(false);
+  const [uploadedProblemsInfo, setUploadedProblemsInfo] = useState<
+    RegisterProblemParams[]
+  >([]);
+  const [problemsInfo, setProblemsInfo] = useState<ProblemInfo[]>([]);
+  const [openUploadExamProblemsModal, setOpenUploadExamProblemsModal] =
+    useState<string | undefined>();
+  const [openUploadingExamProblemsModal, setOpenUploadingExamProblemsModal] =
+    useState<string | undefined>();
+
+  const [uploadService] = useState(new UploadService()); // UploadService 인스턴스 생성
+
+  const router = useRouter();
+
+  const queryClient = useQueryClient();
+
+  const results = useQueries({
+    queries: [
+      {
+        queryKey: ['fetchExamDetailInfo', eid],
+        queryFn: fetchExamDetailInfo,
+      },
+      {
+        queryKey: ['examProblemsDetailInfo', eid],
+        queryFn: fetchExamProblemsDetailInfo,
+      },
+    ],
+  });
+
+  const examInfo: ExamInfo = results[0].data?.data.data;
+  const examProblemsInfo: ProblemsInfo = results[1].data?.data.data;
+
+  const currentTime = new Date();
+  const examStartTime = new Date(examProblemsInfo?.testPeriod.start);
+  const examEndTime = new Date(examProblemsInfo?.testPeriod.end);
+
+  useEffect(() => {
+    if (examProblemsInfo) {
+      setProblemsInfo(examProblemsInfo.problems);
+    }
+  }, [examProblemsInfo]);
+
+  const { getRootProps } = useDropzone({
+    onDrop: async (acceptedFiles) => {
+      if (acceptedFiles.length === 0) return;
+
+      const file = acceptedFiles[0];
+      setExcelFileName(file.name);
+
+      // 파일 업로드
+      try {
+        const response = await uploadService.upload(file);
+        const newFile = response.data;
+        setExcelFileUrl(newFile.url); // 업로드된 파일의 URL 설정
+        setIsExcelFileUploadingValidFail(true);
+      } catch (error) {
+        console.error('File upload error:', error);
+        setIsExcelFileUploadingValidFail(false);
+      }
+
+      // 엑셀 데이터 파싱
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const data = new Uint8Array(event.target?.result as ArrayBuffer);
+        const workbook = XLSX.read(data, { type: 'array' });
+
+        // 첫 번째 시트 가져오기
+        const sheetName = workbook.SheetNames[0];
+        const worksheet = workbook.Sheets[sheetName];
+
+        // 시트 데이터를 JSON으로 변환 (4행부터 시작, A–D 열만)
+        const jsonData = XLSX.utils.sheet_to_json(worksheet, {
+          header: ['A', 'B', 'C'], // 열 이름 지정
+          range: 3, // 4행부터 시작
+        }) as Array<{ A: string; B: number; C: number; D: number }>;
+
+        // RegisterProblemParams 배열로 변환
+        const formattedData: RegisterProblemParams[] = jsonData.map((row) => ({
+          title: row.A || '',
+          content: '',
+          published: null,
+          ioSet: [],
+          options: {
+            maxRealTime: row.B || 0,
+            maxMemory: row.C || 0,
+          },
+        }));
+
+        console.log('Formatted Data:', formattedData);
+
+        // 변환된 데이터 업데이트
+        setUploadedProblemsInfo(formattedData);
+      };
+
+      reader.readAsArrayBuffer(file);
+    },
+    accept: {
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [
+        '.xlsx',
+      ],
+    },
+    multiple: false,
+  });
+
+  const handleBulkRegister = async () => {
+    let hasMissingData = false;
+
+    // 데이터 검증
+    uploadedProblemsInfo.forEach((problem) => {
+      if (!problem.content || !problem.ioSet || problem.ioSet.length === 0) {
+        hasMissingData = true;
+      }
+    });
+
+    if (hasMissingData) {
+      addToast(
+        'warning',
+        '문제 파일 또는 입/출력 파일 셋을 모두 등록해 주세요.',
+      );
+      return;
+    }
+
+    // 모달 창 표시
+    setOpenUploadingExamProblemsModal('default');
+
+    try {
+      let successCount = 0;
+
+      // 등록 요청을 순차적으로 처리
+      for (const problem of uploadedProblemsInfo) {
+        try {
+          await axiosInstance.post(
+            `${process.env.NEXT_PUBLIC_API_VERSION}/problem`,
+            {
+              ...problem,
+              parentType: 'Assignment', // 추가 필드
+              parentId: eid, // 필요한 경우 동적으로 설정
+            },
+          );
+
+          // 성공 시 성공 카운트 증가
+          successCount++;
+        } catch (error) {
+          console.error(`문제 "${problem.title}" 등록 중 에러 발생:`, error);
+          addToast('error', `문제 "${problem.title}" 등록 실패.`);
+        }
+
+        // 각 요청 간의 지연 추가 (500ms)
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+
+      // 모든 요청 완료 후
+      setUploadedProblemsInfo([]); // 상태 초기화
+      addToast('success', `문제 ${successCount}개를 등록했어요.`);
+
+      queryClient.invalidateQueries({
+        queryKey: ['examProblemsDetailInfo'],
+      });
+    } catch (error) {
+      console.error('문제 등록 중 전반적인 에러 발생:', error);
+      addToast('error', '문제 등록 중 전반적인 에러가 발생했습니다.');
+    } finally {
+      // 모달 창 닫기
+      setOpenUploadingExamProblemsModal(undefined);
+    }
+  };
+
+  // (로그인 한) 사용자 정보 조회 및 관리자 권한 확인
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      if (examInfo) {
+        const isWriter = examInfo.writer._id === userInfo._id;
+
+        if (currentTime >= examStartTime) {
+          addToast('warning', '대회 시작 후에는 등록할 수 없어요.');
+          router.back();
+          return;
+        }
+
+        if (isWriter) {
+          setIsLoading(false);
+          return;
+        }
+
+        addToast('warning', '접근 권한이 없어요.');
+        router.push('/');
+      }
+    });
+  }, [updateUserInfo, examInfo, router, addToast]);
+
+  if (isLoading) return <Loading />;
+
+  console.log(problemsInfo);
+
+  return (
+    <div className="mt-2 px-5 2lg:px-0 overflow-x-auto min-h-[40rem]">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <button
+          onClick={() => {
+            router.push(`/exams/${eid}/problems`);
+          }}
+          className="flex items-center gap-x-1"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="18"
+            viewBox="0 -960 960 960"
+            width="18"
+            fill="#656565"
+          >
+            <path d="M233-440h607q17 0 28.5-11.5T880-480q0-17-11.5-28.5T840-520H233l155-156q11-11 11.5-27.5T388-732q-11-11-28-11t-28 11L108-508q-6 6-8.5 13T97-480q0 8 2.5 15t8.5 13l224 224q11 11 27.5 11t28.5-11q12-12 12-28.5T388-285L233-440Z" />
+          </svg>
+          <span className="text-[#656565] text-xs font-light hover:text-black py-[0.5rem]">
+            뒤로가기
+          </span>
+        </button>
+
+        <div className="h-16 flex justify-between items-center text-[27px] font-semibold tracking-wide overflow-hidden">
+          <span className="lift-up">문제 한 번에 등록</span>
+
+          <div className="flex gap-2">
+            {uploadedProblemsInfo.length !== 0 ? (
+              <>
+                <button
+                  onClick={() => {
+                    setOpenUploadExamProblemsModal('default');
+                  }}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#f2f4f6] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#d3d6da]"
+                >
+                  <span
+                    aria-hidden="false"
+                    role="presentation"
+                    style={{
+                      height: '18px',
+                      width: '18px',
+                      minWidth: '18px',
+                      padding: '0px',
+                    }}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <path
+                        fill="#8d95a0"
+                        d="M12.766 6.604a1.108 1.108 0 00-1.198-.237 1.113 1.113 0 00-.358.237L5.504 12.31a1.1 1.1 0 001.555 1.556l3.829-3.83v11.345a1.1 1.1 0 002.2 0V10.038l3.829 3.829c.215.215.496.322.778.322a1.1 1.1 0 00.778-1.878l-5.707-5.707zM21.38 2.1H2.596a1.1 1.1 0 000 2.2h18.785a1.1 1.1 0 100-2.2"
+                        fillRule="evenodd"
+                      ></path>
+                    </svg>
+                  </span>
+                  <span className="text-[#4e5968] whitespace-nowrap">
+                    파일 다시 올리기
+                  </span>
+                </button>
+
+                <button
+                  onClick={handleBulkRegister}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#3183f6] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#1c6cdb]"
+                >
+                  <span className="text-white whitespace-nowrap">
+                    {uploadedProblemsInfo.length}개 문제 등록하기
+                  </span>
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  onClick={() => {
+                    window.location.href =
+                      '/template/SOJ_시험_문제등록_양식.xlsx';
+                  }}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#e8f3ff] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#cee1fc]"
+                >
+                  <span
+                    aria-hidden="false"
+                    role="presentation"
+                    style={{
+                      height: '18px',
+                      width: '18px',
+                      minWidth: '18px',
+                      padding: '0px',
+                    }}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <g fill="#487fee">
+                        <path d="M11.2 17.7c.1.1.2.2.4.2.3.1.6.1.8 0 .1-.1.3-.1.4-.2l5.7-5.7c.4-.4.4-1.1 0-1.6s-1.1-.4-1.6 0l-3.8 3.8V2.9c0-.6-.5-1.1-1.1-1.1s-1.1.5-1.1 1.1v11.3l-3.8-3.8c-.2-.2-.5-.3-.8-.3s-.6.1-.8.3c-.4.4-.4 1.1 0 1.6l5.7 5.7zM2.6 22.2h18.8c.6 0 1.1-.5 1.1-1.1S22 20 21.4 20H2.6c-.6 0-1.1.5-1.1 1.1s.5 1.1 1.1 1.1z"></path>
+                      </g>
+                    </svg>
+                  </span>
+                  <span className="text-[#1b64da] whitespace-nowrap">
+                    문제 등록 양식 다운받기
+                  </span>
+                </button>
+
+                <button
+                  onClick={() => setOpenUploadExamProblemsModal('default')}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#3183f6] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#1c6cdb]"
+                >
+                  <span
+                    aria-hidden="false"
+                    role="presentation"
+                    style={{
+                      height: '18px',
+                      width: '18px',
+                      minWidth: '18px',
+                      padding: '0px',
+                    }}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <path
+                        fill="white"
+                        d="M12.766 6.604a1.108 1.108 0 00-1.198-.237 1.113 1.113 0 00-.358.237L5.504 12.31a1.1 1.1 0 001.555 1.556l3.829-3.83v11.345a1.1 1.1 0 002.2 0V10.038l3.829 3.829c.215.215.496.322.778.322a1.1 1.1 0 00.778-1.878l-5.707-5.707zM21.38 2.1H2.596a1.1 1.1 0 000 2.2h18.785a1.1 1.1 0 100-2.2"
+                        fillRule="evenodd"
+                      ></path>
+                    </svg>
+                  </span>
+                  <span className="text-white whitespace-nowrap">
+                    문제 한 번에 등록하기
+                  </span>
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {uploadedProblemsInfo.length !== 0 ? (
+          <div>
+            <label
+              {...getRootProps()}
+              className="mt-4 flex justify-between items-center pl-4 pr-2 py-[0.4rem] bg-white border-none outline outline-1 outline-[#e6e8ea] hover:outline-2 hover:outline-[#a3c6fa] hover:outline-offset-[-1px] rounded-[7px] duration-100"
+            >
+              <div className="flex items-center gap-x-2">
+                <span
+                  className="icon p-icon p-menu__item__addon"
+                  aria-hidden="false"
+                  role="presentation"
+                >
+                  <svg
+                    height="20"
+                    width="20"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <mask id="a" fill="#fff">
+                      <path
+                        d="m0 0h20v19.9996h-20z"
+                        fill="#fff"
+                        fillRule="evenodd"
+                      ></path>
+                    </mask>
+                    <g
+                      fill="#26a06b"
+                      fillRule="evenodd"
+                      transform="translate(2 2)"
+                    >
+                      <path d="m13 14.1719v5.828l7-7h-5.828c-.649 0-1.162.523-1.162 1.162"></path>
+                      <path
+                        d="m5.918 5.6036 1.971 2.893c.061.381-.228.489-.559.489h-.746c-.321-.016-.379-.033-.585-.4l-1.016-1.865-.013-.015-.013.015-1.016 1.865c-.206.367-.264.384-.585.4h-.746c-.331 0-.62-.108-.559-.489l1.971-2.893.001-.001-.038-.044-1.9-2.82c-.15-.217.122-.517.502-.517h.746c.331 0 .372.043.538.315l1.084 1.926.015.018.015-.018 1.084-1.926c.166-.272.207-.315.538-.315h.746c.38 0 .652.3.503.517l-1.901 2.82-.038.044zm12.9-5.604h-17.636c-.654 0-1.182.528-1.182 1.182v17.647c0 .654.528 1.171 1.172 1.171h10.005v-5.878c0-1.626 1.319-2.945 2.944-2.945h5.879v-9.995c0-.654-.528-1.182-1.182-1.182z"
+                        mask="url(#a)"
+                      ></path>
+                    </g>
+                  </svg>
+                </span>
+
+                <span className="text-[15px] text-[#4e5968]">
+                  {excelFileName}
+                </span>
+              </div>
+
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setUploadedProblemsInfo([]);
+                }}
+                className="flex justify-center items-center gap-[0.375rem] text-[13px] text-[#4e5968] bg-[#f2f4f6] px-3 py-1 rounded-[6px] font-light focus:bg-[#d3d6da] hover:bg-[#e6e8ea]"
+              >
+                삭제
+              </button>
+            </label>
+
+            <div className="mt-10">
+              <div className="flex items-center gap-x-[0.6rem] mb-3">
+                <span className="font-semibold text-[19px] text-[#333d4b]">
+                  등록될 문제
+                </span>
+                <span className="text-[#6d7683] text-[0.825rem] font-light">
+                  {uploadedProblemsInfo.length}개
+                </span>
+              </div>
+
+              <UploadedProblemList
+                problemsInfo={uploadedProblemsInfo}
+                setUploadedProblemsInfo={setUploadedProblemsInfo}
+              />
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="py-2">
+              <div className="flex mt-4 justify-between items-center">
+                <span className="text-[#6d7683] text-[0.825rem] font-light">
+                  총{' '}
+                  <span className="text-[#6d7683]">{problemsInfo.length}</span>
+                  개
+                </span>
+              </div>
+
+              <ExamProblemList
+                eid={eid}
+                problemsInfo={problemsInfo}
+                setProblemsInfo={setProblemsInfo}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      {openUploadingExamProblemsModal && (
+        <UploadingExamProblemsModal
+          openUploadingExamProblemsModal={openUploadingExamProblemsModal}
+          setOpenUploadingExamProblemsModal={setOpenUploadingExamProblemsModal}
+        />
+      )}
+
+      {openUploadExamProblemsModal && (
+        <UploadExamProblemsModal
+          setExcelFileName={setExcelFileName}
+          setUploadedProblemsInfo={setUploadedProblemsInfo}
+          excelFileUrl={excelFileUrl}
+          setExcelFileUrl={setExcelFileUrl}
+          isExcelFileUploadingValidFail={isExcelFileUploadingValidFail}
+          setIsExcelFileUploadingValidFail={setIsExcelFileUploadingValidFail}
+          openUploadExamProblemsModal={openUploadExamProblemsModal}
+          setOpenUploadExamProblemsModal={setOpenUploadExamProblemsModal}
+        />
+      )}
+    </div>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/UploadPracticeProblemsModal.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/UploadPracticeProblemsModal.tsx
@@ -1,0 +1,100 @@
+import Dropzone from '@/app/components/Dropzone';
+import MyDropzone from '@/app/components/MyDropzone';
+import { IoSetItem, ProblemInfo, RegisterProblemParams } from '@/types/problem';
+import { Modal } from 'flowbite-react';
+import React, { useEffect, useState } from 'react';
+
+interface UploadPracticeProblemsModalProps {
+  setExcelFileName: React.Dispatch<React.SetStateAction<string>>;
+  setUploadedProblemsInfo: React.Dispatch<
+    React.SetStateAction<RegisterProblemParams[]>
+  >;
+  excelFileUrl: string;
+  setExcelFileUrl: React.Dispatch<React.SetStateAction<string>>;
+  isExcelFileUploadingValidFail: boolean;
+  setIsExcelFileUploadingValidFail: React.Dispatch<
+    React.SetStateAction<boolean>
+  >;
+  openUploadPracticeProblemsModal: string | undefined;
+  setOpenUploadPracticeProblemsModal: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+}
+
+export default function UploadPracticeProblemsModal({
+  setExcelFileName,
+  setUploadedProblemsInfo,
+  excelFileUrl,
+  setExcelFileUrl,
+  isExcelFileUploadingValidFail,
+  setIsExcelFileUploadingValidFail,
+  openUploadPracticeProblemsModal,
+  setOpenUploadPracticeProblemsModal,
+}: UploadPracticeProblemsModalProps) {
+  const [tempUploadedProblemsInfo, setTempUploadedProblemsInfo] = useState<
+    RegisterProblemParams[]
+  >([]);
+
+  useEffect(() => {
+    setIsExcelFileUploadingValidFail(false);
+  }, [setIsExcelFileUploadingValidFail]);
+
+  return (
+    <Modal
+      show={openUploadPracticeProblemsModal === 'default'}
+      onClose={() => setOpenUploadPracticeProblemsModal(undefined)}
+      className="modal"
+      size="xl"
+    >
+      <Modal.Body className="flex flex-col gap-y-1 items-start pt-7 pb-0 px-5">
+        <span className="text-[20px] font-semibold">문제 한 번에 등록하기</span>
+
+        <span className="text-[17px] text-[#4e5968] font-medium">
+          엑셀 양식에 문제 정보를 모두 써준 뒤 파일을 올리면 문제를 한 번에
+          등록할 수 있어요.
+        </span>
+
+        <button
+          onClick={() => {
+            window.location.href = '/template/SOJ_연습_문제등록_양식.xlsx';
+          }}
+          className="text-[17px] text-[#007bff] hover:text-[#002fa6] font-medium underline hover:no-underline"
+        >
+          문제 등록 양식 다운받기
+        </button>
+
+        <div className="w-full mt-2 mb-1">
+          <Dropzone
+            type="file"
+            guideMsg="파일을 선택하거나 올려 주세요"
+            guideMsg2="10MB 이하"
+            setExcelFileName={setExcelFileName}
+            setIsFileUploaded={setIsExcelFileUploadingValidFail}
+            isFileUploaded={isExcelFileUploadingValidFail}
+            fileUrl={excelFileUrl}
+            setFileUrl={setExcelFileUrl}
+            setUploadedProblemsInfo={setTempUploadedProblemsInfo}
+          />
+        </div>
+      </Modal.Body>
+      <Modal.Footer className="flex justify-between border-none pt-4">
+        <button
+          onClick={() => setOpenUploadPracticeProblemsModal(undefined)}
+          className="flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.5rem] rounded-[7px] font-medium focus:bg-[#d3d6da] hover:bg-[#d3d6da]"
+        >
+          닫기
+        </button>
+
+        <button
+          onClick={() => {
+            setUploadedProblemsInfo(tempUploadedProblemsInfo);
+            setOpenUploadPracticeProblemsModal(undefined);
+          }}
+          className="flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-white bg-[#3a8af9] px-3 py-[0.5rem] rounded-[6px] font-medium  hover:bg-[#1c6cdb]"
+        >
+          등록하기
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/UploadingPracticeProblemsModal.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/UploadingPracticeProblemsModal.tsx
@@ -1,0 +1,73 @@
+import Dropzone from '@/app/components/Dropzone';
+import MyDropzone from '@/app/components/MyDropzone';
+import { IoSetItem, ProblemInfo, RegisterProblemParams } from '@/types/problem';
+import { Modal } from 'flowbite-react';
+import React, { useEffect, useState } from 'react';
+
+interface UploadingPracticeProblemsModalProps {
+  openUploadingPracticeProblemsModal: string | undefined;
+  setOpenUploadingPracticeProblemsModal: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
+}
+
+export default function UploadingPracticeProblemsModal({
+  openUploadingPracticeProblemsModal,
+  setOpenUploadingPracticeProblemsModal,
+}: UploadingPracticeProblemsModalProps) {
+  const [tempUploadedProblemsInfo, setTempUploadedProblemsInfo] = useState<
+    RegisterProblemParams[]
+  >([]);
+
+  return (
+    <Modal
+      show={openUploadingPracticeProblemsModal === 'default'}
+      onClose={() => setOpenUploadingPracticeProblemsModal(undefined)}
+      className="modal"
+      size="xl"
+    >
+      <Modal.Body className="flex flex-col gap-y-1 items-start pt-7 pb-0 px-5 overflow-hidden">
+        <span className="text-[20px] font-semibold">
+          문제를 등록하는 중이에요
+        </span>
+
+        <span className="text-[17px] text-[#4e5968] font-medium">
+          문제 등록이 완료될 때까지 화면을 닫지 말아주세요.
+        </span>
+
+        <svg
+          viewBox="0 0 100 100"
+          width="110"
+          height="110"
+          className="svg-loading-animation mx-auto h-[10rem]"
+        >
+          <circle
+            fill="none"
+            stroke="#d8d8dc"
+            strokeWidth="9"
+            strokeMiterlimit="10"
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+            cx="50"
+            cy="50"
+            r="28"
+          ></circle>
+          <circle
+            fill="none"
+            stroke="#477eed"
+            strokeWidth="9"
+            strokeMiterlimit="10"
+            strokeLinecap="round"
+            strokeLinejoin="miter"
+            cx="50"
+            cy="50"
+            r="28"
+            strokeDasharray="226.2"
+            strokeDashoffset="190"
+            className="circle-dash-animation"
+          ></circle>
+        </svg>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/practiceProblems/EmptyPracticeProblemListItem.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/practiceProblems/EmptyPracticeProblemListItem.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function EmptyPracticeProblemListItem() {
+  return (
+    <tr className="h-[2.5rem] border-b-[1.25px] border-[#d1d6db] text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-[#4e5968]">문제 정보가 존재하지 않아요</td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/practiceProblems/PracticeProblemList.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/practiceProblems/PracticeProblemList.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { ProblemInfo } from '@/types/problem';
+import PracticeProblemListItem from './PracticeProblemListItem';
+
+interface PracticeProblemListProps {
+  problemsInfo: ProblemInfo[];
+  setProblemsInfo: (problemsInfo: ProblemInfo[]) => void;
+}
+
+export default function PracticeProblemList({
+  problemsInfo,
+  setProblemsInfo,
+}: PracticeProblemListProps) {
+  return (
+    <div className="mt-3 relative overflow-hidden rounded-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left text-gray-500 ">
+          <thead className="border-y-[1.25px] border-[#d1d6db] text-[15px] uppercase bg-[#f2f4f6] text-center">
+            <tr className="h-[2.75rem]">
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] w-16 px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                번호
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제명
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 실행 시간
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 메모리 사용량
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                점수
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제 파일
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {problemsInfo.length !== 0 && (
+              <>
+                {problemsInfo.map((problemInfo, index) => (
+                  <PracticeProblemListItem
+                    problemInfo={problemInfo}
+                    total={problemsInfo.length}
+                    index={index}
+                    key={index}
+                  />
+                ))}
+              </>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/practiceProblems/PracticeProblemListItem.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/practiceProblems/PracticeProblemListItem.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { ProblemInfo, IoSetItem, ExampleFile } from '@/types/problem';
+
+interface PracticeProblemListItemProps {
+  problemInfo: ProblemInfo;
+  total: number;
+  index: number;
+}
+
+export default function PracticeProblemListItem(
+  props: PracticeProblemListItemProps,
+) {
+  const { problemInfo, total, index } = props;
+
+  return (
+    <tr className="h-[3rem] border-b-[1.25px] border-[#d1d6db] text-[15px] text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        {index + 1}
+      </th>
+      <td scope="row" className="text-[#4e5968]">
+        {problemInfo.title}
+      </td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxRealTime}</td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxMemory}</td>
+      <td className="text-[#4e5968]">{problemInfo.score}</td>
+      <td>
+        <a
+          target="_blank"
+          href={problemInfo.content}
+          className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+        >
+          보기
+        </a>
+      </td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/skeleton/PracticeDetailContentLoadingSkeleton.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/skeleton/PracticeDetailContentLoadingSkeleton.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+export default function PracticeDetailContentLoadingSkeleton() {
+  return (
+    <div className="flex flex-col gap-y-2 pb-5">
+      <div className="flex gap-x-2">
+        <div className="skeleton w-[5rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[7.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[6rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+
+      <div className="mt-4 flex gap-x-2">
+        <div className="skeleton w-[5rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+        <div className="skeleton w-[7.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+        <div className="skeleton w-[5rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+      <div className="flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+      <div className="flex gap-x-2">
+        <div className="skeleton w-[6rem] h-[1rem]" />
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+
+      <div className="mt-4 flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[3rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+      <div className="ml-4 flex gap-x-2">
+        <div className="skeleton w-[10rem] h-[1rem]" />
+        <div className="skeleton w-[5rem] h-[1rem]" />
+      </div>
+
+      <div className="mt-4 flex gap-x-2">
+        <div className="skeleton w-[7.5rem] h-[1rem]" />
+        <div className="skeleton w-[12.5rem] h-[1rem]" />
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/skeleton/PracticeDetailPageLoadingSkeleton.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/skeleton/PracticeDetailPageLoadingSkeleton.tsx
@@ -1,0 +1,23 @@
+import PracticeDetailContentLoadingSkeleton from './PracticeDetailContentLoadingSkeleton';
+
+export default function PracticeDetailPageLoadingSkeleton() {
+  return (
+    <div className="mt-6 mb-24 w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col pb-3 border-b border-gray-300">
+        <div className="skeleton w-[30rem] h-[2rem]" />
+        <div className="mt-8 flex justify-between">
+          <div className="flex gap-x-2 h-[1.25rem]">
+            <div className="skeleton w-[17.5rem]" />
+            <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
+            <div className="skeleton w-[20rem]" />
+          </div>
+          <div className="skeleton w-[7.5rem]" />
+        </div>
+      </div>
+
+      <div className="mt-8 border-b">
+        <PracticeDetailContentLoadingSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/uploadedProblems/EmptyProblemListItem.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/uploadedProblems/EmptyProblemListItem.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function EmptyProblemListItem() {
+  return (
+    <tr className="h-[2.5rem] border-b-[1.25px] border-[#d1d6db] text-xs text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        1
+      </th>
+      <td className="text-[#4e5968]">문제 정보가 존재하지 않아요</td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/uploadedProblems/UploadedProblemList.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/uploadedProblems/UploadedProblemList.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { RegisterProblemParams } from '@/types/problem';
+import UploadedProblemListItem from './UploadedProblemListItem';
+
+interface UploadedProblemListProps {
+  problemsInfo: RegisterProblemParams[];
+  setUploadedProblemsInfo: React.Dispatch<
+    React.SetStateAction<RegisterProblemParams[]>
+  >;
+}
+
+export default function UploadedProblemList({
+  problemsInfo,
+  setUploadedProblemsInfo,
+}: UploadedProblemListProps) {
+  return (
+    <div className="mt-3 relative overflow-hidden rounded-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left text-gray-500 ">
+          <thead className="border-y-[1.25px] border-[#d1d6db] text-[15px] uppercase bg-[#f2f4f6] text-center">
+            <tr className="h-[2.75rem]">
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] w-16 px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                번호
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제명
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 실행 시간
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                최대 메모리 사용량
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                점수
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                문제 파일
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                입/출력 파일 셋
+              </th>
+              <th
+                scope="col"
+                className="font-normal text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
+              >
+                예제 파일
+                <span className="text-[10px] text-[#333d4b] font-normal">
+                  (선택)
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {problemsInfo.length !== 0 && (
+              <>
+                {problemsInfo.map((problemInfo, index) => (
+                  <UploadedProblemListItem
+                    setUploadedProblemsInfo={setUploadedProblemsInfo}
+                    problemInfo={problemInfo}
+                    total={problemsInfo.length}
+                    index={index}
+                    key={index}
+                  />
+                ))}
+              </>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/components/uploadedProblems/UploadedProblemListItem.tsx
+++ b/judger-frontend/app/practices/register/multiple/components/uploadedProblems/UploadedProblemListItem.tsx
@@ -1,0 +1,295 @@
+import { ExampleFile, IoSetItem, RegisterProblemParams } from '@/types/problem';
+import { UploadService } from '@/components/utils/uploadService';
+import { useState, useCallback } from 'react';
+import { Accept, useDropzone } from 'react-dropzone';
+
+interface UploadedProblemListItemProps {
+  problemInfo: RegisterProblemParams;
+  setUploadedProblemsInfo: React.Dispatch<
+    React.SetStateAction<RegisterProblemParams[]>
+  >;
+  total: number;
+  index: number;
+}
+
+export default function UploadedProblemListItem(
+  props: UploadedProblemListItemProps,
+) {
+  const { problemInfo, setUploadedProblemsInfo, index } = props;
+
+  const [uploadService] = useState(new UploadService());
+
+  const getAcceptTypes = (type: string): Accept => {
+    switch (type) {
+      case 'pdf':
+        return { 'application/pdf': ['.pdf'] };
+      case 'in/out':
+        return { 'text/plain': ['.in', '.out'] };
+      case 'exampleFile':
+        return {
+          'application/temp': [
+            '.c',
+            '.cpp',
+            '.java',
+            '.js',
+            '.py',
+            '.kt',
+            '.go',
+          ],
+        };
+      default:
+        return {};
+    }
+  };
+
+  const isMultipleFileAllowed = (fileType: string): boolean => {
+    const multipleFileTypes = ['in/out', 'exampleFile'];
+    return multipleFileTypes.includes(fileType);
+  };
+
+  const openFileContent = async (url: string, filename: string) => {
+    try {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch file: ${response.statusText}`);
+      }
+
+      const text = await response.text();
+
+      const newWindow = window.open('', '_blank');
+      if (newWindow) {
+        newWindow.document.write(`
+          <html>
+            <head>
+              <title>${filename}</title>
+            </head>
+            <body>
+              <pre>${text}</pre>
+            </body>
+          </html>
+        `);
+        newWindow.document.close();
+      } else {
+        console.warn(
+          'Failed to open new window. Please check popup blocker settings.',
+        );
+      }
+    } catch (error) {
+      console.error('Error opening file:', error);
+    }
+  };
+
+  const openUrlsInNewTabs = (items: IoSetItem[] | ExampleFile[]) => {
+    if (items.length === 0) {
+      console.warn('No items to open');
+      return;
+    }
+
+    if ('url' in items[0]) {
+      (items as ExampleFile[]).forEach((file) => {
+        if (file.url) {
+          openFileContent(file.url, file.filename);
+        } else {
+          console.warn('File URL is missing', file);
+        }
+      });
+    } else if ('inFile' in items[0] && 'outFile' in items[0]) {
+      (items as IoSetItem[]).forEach((io) => {
+        openFileContent(io.inFile.url, io.inFile.filename);
+        openFileContent(io.outFile.url, io.outFile.filename);
+      });
+    } else {
+      console.error('Invalid input: Expected ExampleFile or IoSetItem array');
+    }
+  };
+
+  const handleDrop = useCallback(
+    async (acceptedFiles: File[], fileType: string) => {
+      if (acceptedFiles.length === 0) return;
+
+      try {
+        if (fileType === 'in/out') {
+          const fileGroups: { [key: string]: File[] } = {};
+          acceptedFiles.forEach((file) => {
+            const baseName = file.name.replace(/\.(in|out)$/, '');
+            if (!fileGroups[baseName]) {
+              fileGroups[baseName] = [];
+            }
+            fileGroups[baseName].push(file);
+          });
+
+          const ioSetPromises = Object.entries(fileGroups)
+            .filter(
+              ([_, files]) =>
+                files.some((f) => f.name.endsWith('.in')) &&
+                files.some((f) => f.name.endsWith('.out')),
+            )
+            .map(async ([_, files]) => {
+              const inFile = files.find((f) => f.name.endsWith('.in'));
+              const outFile = files.find((f) => f.name.endsWith('.out'));
+
+              if (!inFile || !outFile) return null;
+
+              const inFileResponse = await uploadService.upload(inFile);
+              const outFileResponse = await uploadService.upload(outFile);
+
+              return {
+                inFile: { ...inFileResponse.data, filename: inFile.name },
+                outFile: { ...outFileResponse.data, filename: outFile.name },
+              } as IoSetItem;
+            });
+
+          const validIoSets = (await Promise.all(ioSetPromises)).filter(
+            Boolean,
+          ) as IoSetItem[];
+
+          setUploadedProblemsInfo((prev) => {
+            const updatedProblems = [...prev];
+            const updatedProblem = { ...updatedProblems[index] };
+            updatedProblem.ioSet = [
+              ...(updatedProblem.ioSet || []),
+              ...validIoSets,
+            ];
+            updatedProblems[index] = updatedProblem;
+            return updatedProblems;
+          });
+        } else if (fileType === 'pdf') {
+          const file = acceptedFiles[0];
+          const response = await uploadService.upload(file);
+
+          setUploadedProblemsInfo((prev) => {
+            const updatedProblems = [...prev];
+            const updatedProblem = { ...updatedProblems[index] };
+
+            updatedProblem.content = response.data.url;
+
+            updatedProblems[index] = updatedProblem;
+            return updatedProblems;
+          });
+        } else if (fileType === 'exampleFile') {
+          const exampleFilePromises = acceptedFiles.map(async (file) => {
+            const response = await uploadService.upload(file);
+
+            return {
+              ref: response.data.ref,
+              _id: response.data._id,
+              filename: file.name,
+              url: response.data.url,
+            } as ExampleFile;
+          });
+
+          const uploadedFiles = await Promise.all(exampleFilePromises);
+
+          setUploadedProblemsInfo((prev) => {
+            const updatedProblems = [...prev];
+            const updatedProblem = { ...updatedProblems[index] };
+
+            updatedProblem.exampleFiles = [
+              ...(updatedProblem.exampleFiles || []),
+              ...uploadedFiles,
+            ];
+
+            updatedProblems[index] = updatedProblem;
+            return updatedProblems;
+          });
+        }
+      } catch (error) {
+        console.error(`${fileType} 파일 업로드 실패:`, error);
+      }
+    },
+    [uploadService, setUploadedProblemsInfo, index],
+  );
+
+  // 미리 모든 파일 타입의 Dropzone 설정을 생성
+  const dropzones = {
+    pdf: useDropzone({
+      onDrop: (acceptedFiles) => handleDrop(acceptedFiles, 'pdf'),
+      accept: getAcceptTypes('pdf'),
+      multiple: isMultipleFileAllowed('pdf'),
+    }),
+    inOut: useDropzone({
+      onDrop: (acceptedFiles) => handleDrop(acceptedFiles, 'in/out'),
+      accept: getAcceptTypes('in/out'),
+      multiple: isMultipleFileAllowed('in/out'),
+    }),
+    exampleFile: useDropzone({
+      onDrop: (acceptedFiles) => handleDrop(acceptedFiles, 'exampleFile'),
+      accept: getAcceptTypes('exampleFile'),
+      multiple: isMultipleFileAllowed('exampleFile'),
+    }),
+  };
+
+  return (
+    <tr className="h-[3rem] border-b-[1.25px] border-[#d1d6db] text-[15px] text-center">
+      <th
+        scope="row"
+        className="px-4 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
+      >
+        {index + 1}
+      </th>
+      <td scope="row" className="text-[#4e5968]">
+        {problemInfo.title}
+      </td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxRealTime}</td>
+      <td className="text-[#4e5968]">{problemInfo.options.maxMemory}</td>
+      <td className="text-[#4e5968]">{problemInfo.score}</td>
+      <td
+        onClick={() => {
+          ('pdf');
+        }}
+      >
+        {problemInfo.content ? (
+          <a
+            target="_blank"
+            href={problemInfo.content}
+            className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+          >
+            보기
+          </a>
+        ) : (
+          <label
+            {...dropzones.pdf.getRootProps()}
+            className="inline-block text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.4rem] rounded-[6px] font-medium hover:bg-[#d3d6da] cursor-pointer"
+          >
+            등록
+          </label>
+        )}
+      </td>
+      <td>
+        {problemInfo.ioSet.length === 0 ? (
+          <label
+            {...dropzones.inOut.getRootProps()}
+            className="inline-block text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.4rem] rounded-[6px] font-medium hover:bg-[#d3d6da] cursor-pointer"
+          >
+            등록
+          </label>
+        ) : (
+          <button
+            onClick={() => openUrlsInNewTabs(problemInfo.ioSet)}
+            className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+          >
+            보기
+          </button>
+        )}
+      </td>
+      <td>
+        {problemInfo.exampleFiles?.length ? (
+          <button
+            onClick={() => openUrlsInNewTabs(problemInfo.exampleFiles || [])}
+            className="inline-block text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-[0.4rem] rounded-[6px] font-medium cursor-pointer hover:bg-[#cee1fc]"
+          >
+            보기
+          </button>
+        ) : (
+          <label
+            {...dropzones.exampleFile.getRootProps()}
+            className="inline-block text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-[0.4rem] rounded-[6px] font-medium hover:bg-[#d3d6da] cursor-pointer"
+          >
+            등록
+          </label>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/judger-frontend/app/practices/register/multiple/page.tsx
+++ b/judger-frontend/app/practices/register/multiple/page.tsx
@@ -1,0 +1,466 @@
+'use client';
+
+import axiosInstance from '@/utils/axiosInstance';
+import React, { useEffect, useState } from 'react';
+import { ProblemInfo, RegisterProblemParams } from '@/types/problem';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import UploadPracticeProblemsModal from './components/UploadPracticeProblemsModal';
+import { useDropzone } from 'react-dropzone';
+import * as XLSX from 'xlsx';
+import { UploadService } from '@/components/utils/uploadService';
+import UploadedProblemList from './components/uploadedProblems/UploadedProblemList';
+import { ToastInfoStore } from '@/store/ToastInfo';
+import { useRouter } from 'next/navigation';
+import UploadingPracticeProblemsModal from './components/UploadingPracticeProblemsModal';
+import { fetchCurrentUserInfo } from '@/utils/fetchCurrentUserInfo';
+import { UserInfo } from '@/types/user';
+import { userInfoStore } from '@/store/UserInfo';
+import Loading from '@/app/components/Loading';
+import PracticeProblemList from './components/practiceProblems/PracticeProblemList';
+import { OPERATOR_ROLES } from '@/constants/role';
+
+const fetchPractices = async ({ queryKey }: any) => {
+  const response = await axiosInstance.get(
+    `${process.env.NEXT_PUBLIC_API_VERSION}/practice`,
+  );
+  return response.data;
+};
+
+interface DefaultProps {
+  params: {
+    cid: string;
+  };
+}
+
+export default function RegisterMultiplePracticeProblem(props: DefaultProps) {
+  const cid = props.params.cid;
+
+  const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
+
+  const addToast = ToastInfoStore((state) => state.addToast);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [excelFileName, setExcelFileName] = useState('');
+  const [excelFileUrl, setExcelFileUrl] = useState('');
+  const [isExcelFileUploadingValidFail, setIsExcelFileUploadingValidFail] =
+    useState(false);
+  const [uploadedProblemsInfo, setUploadedProblemsInfo] = useState<
+    RegisterProblemParams[]
+  >([]);
+  const [problemsInfo, setProblemsInfo] = useState<ProblemInfo[]>([]);
+  const [openUploadPracticeProblemsModal, setOpenUploadPracticeProblemsModal] =
+    useState<string | undefined>();
+  const [
+    openUploadingPracticeProblemsModal,
+    setOpenUploadingPracticeProblemsModal,
+  ] = useState<string | undefined>();
+
+  const [uploadService] = useState(new UploadService()); // UploadService 인스턴스 생성
+
+  const router = useRouter();
+
+  const queryClient = useQueryClient();
+
+  const { isPending, data } = useQuery({
+    queryKey: ['practiceList'],
+    queryFn: fetchPractices,
+    retry: 0,
+  });
+
+  const practiceProblemsInfo = data?.data.documents;
+
+  useEffect(() => {
+    if (practiceProblemsInfo) {
+      setProblemsInfo(practiceProblemsInfo);
+    }
+  }, [practiceProblemsInfo]);
+
+  const { getRootProps } = useDropzone({
+    onDrop: async (acceptedFiles) => {
+      if (acceptedFiles.length === 0) return;
+
+      const file = acceptedFiles[0];
+      setExcelFileName(file.name);
+
+      // 파일 업로드
+      try {
+        const response = await uploadService.upload(file);
+        const newFile = response.data;
+        setExcelFileUrl(newFile.url); // 업로드된 파일의 URL 설정
+        setIsExcelFileUploadingValidFail(true);
+      } catch (error) {
+        console.error('File upload error:', error);
+        setIsExcelFileUploadingValidFail(false);
+      }
+
+      // 엑셀 데이터 파싱
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const data = new Uint8Array(event.target?.result as ArrayBuffer);
+        const workbook = XLSX.read(data, { type: 'array' });
+
+        // 첫 번째 시트 가져오기
+        const sheetName = workbook.SheetNames[0];
+        const worksheet = workbook.Sheets[sheetName];
+
+        // 시트 데이터를 JSON으로 변환 (4행부터 시작, A–D 열만)
+        const jsonData = XLSX.utils.sheet_to_json(worksheet, {
+          header: ['A', 'B', 'C', 'D'], // 열 이름 지정
+          range: 3, // 4행부터 시작
+        }) as Array<{ A: string; B: number; C: number; D: number }>;
+
+        // RegisterProblemParams 배열로 변환
+        const formattedData: RegisterProblemParams[] = jsonData.map((row) => ({
+          title: row.A || '',
+          content: '',
+          published: null,
+          ioSet: [],
+          options: {
+            maxRealTime: row.B || 0,
+            maxMemory: row.C || 0,
+          },
+          score: row.D || 0,
+        }));
+
+        console.log('Formatted Data:', formattedData);
+
+        // 변환된 데이터 업데이트
+        setUploadedProblemsInfo(formattedData);
+      };
+
+      reader.readAsArrayBuffer(file);
+    },
+    accept: {
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [
+        '.xlsx',
+      ],
+    },
+    multiple: false,
+  });
+
+  const handleBulkRegister = async () => {
+    let hasMissingData = false;
+
+    // 데이터 검증
+    uploadedProblemsInfo.forEach((problem) => {
+      if (!problem.content || !problem.ioSet || problem.ioSet.length === 0) {
+        hasMissingData = true;
+      }
+    });
+
+    if (hasMissingData) {
+      addToast(
+        'warning',
+        '문제 파일 또는 입/출력 파일 셋을 모두 등록해 주세요.',
+      );
+      return;
+    }
+
+    // 모달 창 표시
+    setOpenUploadingPracticeProblemsModal('default');
+
+    try {
+      let successCount = 0;
+
+      // 등록 요청을 순차적으로 처리
+      for (const problem of uploadedProblemsInfo) {
+        try {
+          await axiosInstance.post(
+            `${process.env.NEXT_PUBLIC_API_VERSION}/practice`,
+            {
+              ...problem,
+            },
+          );
+
+          // 성공 시 성공 카운트 증가
+          successCount++;
+        } catch (error) {
+          console.error(`문제 "${problem.title}" 등록 중 에러 발생:`, error);
+          addToast('error', `문제 "${problem.title}" 등록 실패.`);
+        }
+
+        // 각 요청 간의 지연 추가 (500ms)
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+
+      // 모든 요청 완료 후
+      setUploadedProblemsInfo([]); // 상태 초기화
+      addToast('success', `문제 ${successCount}개를 등록했어요.`);
+
+      queryClient.invalidateQueries({
+        queryKey: ['practiceList'],
+      });
+    } catch (error) {
+      console.error('문제 등록 중 전반적인 에러 발생:', error);
+      addToast('error', '문제 등록 중 전반적인 에러가 발생했습니다.');
+    } finally {
+      // 모달 창 닫기
+      setOpenUploadingPracticeProblemsModal(undefined);
+    }
+  };
+
+  // 페이지 접근 권한 설정
+  useEffect(() => {
+    fetchCurrentUserInfo(updateUserInfo).then((userInfo: UserInfo) => {
+      const isOperator = OPERATOR_ROLES.includes(userInfo.role);
+
+      if (isOperator) {
+        setIsLoading(false);
+        return;
+      }
+
+      addToast('warning', '접근 권한이 없어요.');
+      router.push('/');
+    });
+  }, [updateUserInfo, router, addToast]);
+
+  if (isLoading) return <Loading />;
+
+  return (
+    <div className="mt-2 px-5 2lg:px-0 overflow-x-auto min-h-[40rem]">
+      <div className="flex flex-col w-[60rem] mx-auto">
+        <button
+          onClick={() => {
+            router.push(`/practices`);
+          }}
+          className="flex items-center gap-x-1"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="18"
+            viewBox="0 -960 960 960"
+            width="18"
+            fill="#656565"
+          >
+            <path d="M233-440h607q17 0 28.5-11.5T880-480q0-17-11.5-28.5T840-520H233l155-156q11-11 11.5-27.5T388-732q-11-11-28-11t-28 11L108-508q-6 6-8.5 13T97-480q0 8 2.5 15t8.5 13l224 224q11 11 27.5 11t28.5-11q12-12 12-28.5T388-285L233-440Z" />
+          </svg>
+          <span className="text-[#656565] text-xs font-light hover:text-black py-[0.5rem]">
+            뒤로가기
+          </span>
+        </button>
+
+        <div className="h-16 flex justify-between items-center text-[27px] font-semibold tracking-wide overflow-hidden">
+          <span className="lift-up">문제 한 번에 등록</span>
+
+          <div className="flex gap-2">
+            {uploadedProblemsInfo.length !== 0 ? (
+              <>
+                <button
+                  onClick={() => {
+                    setOpenUploadPracticeProblemsModal('default');
+                  }}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#f2f4f6] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#d3d6da]"
+                >
+                  <span
+                    aria-hidden="false"
+                    role="presentation"
+                    style={{
+                      height: '18px',
+                      width: '18px',
+                      minWidth: '18px',
+                      padding: '0px',
+                    }}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <path
+                        fill="#8d95a0"
+                        d="M12.766 6.604a1.108 1.108 0 00-1.198-.237 1.113 1.113 0 00-.358.237L5.504 12.31a1.1 1.1 0 001.555 1.556l3.829-3.83v11.345a1.1 1.1 0 002.2 0V10.038l3.829 3.829c.215.215.496.322.778.322a1.1 1.1 0 00.778-1.878l-5.707-5.707zM21.38 2.1H2.596a1.1 1.1 0 000 2.2h18.785a1.1 1.1 0 100-2.2"
+                        fillRule="evenodd"
+                      ></path>
+                    </svg>
+                  </span>
+                  <span className="text-[#4e5968] whitespace-nowrap">
+                    파일 다시 올리기
+                  </span>
+                </button>
+
+                <button
+                  onClick={handleBulkRegister}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#3183f6] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#1c6cdb]"
+                >
+                  <span className="text-white whitespace-nowrap">
+                    {uploadedProblemsInfo.length}개 문제 등록하기
+                  </span>
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  onClick={() => {
+                    window.location.href =
+                      '/template/SOJ_연습_문제등록_양식.xlsx';
+                  }}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#e8f3ff] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#cee1fc]"
+                >
+                  <span
+                    aria-hidden="false"
+                    role="presentation"
+                    style={{
+                      height: '18px',
+                      width: '18px',
+                      minWidth: '18px',
+                      padding: '0px',
+                    }}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <g fill="#487fee">
+                        <path d="M11.2 17.7c.1.1.2.2.4.2.3.1.6.1.8 0 .1-.1.3-.1.4-.2l5.7-5.7c.4-.4.4-1.1 0-1.6s-1.1-.4-1.6 0l-3.8 3.8V2.9c0-.6-.5-1.1-1.1-1.1s-1.1.5-1.1 1.1v11.3l-3.8-3.8c-.2-.2-.5-.3-.8-.3s-.6.1-.8.3c-.4.4-.4 1.1 0 1.6l5.7 5.7zM2.6 22.2h18.8c.6 0 1.1-.5 1.1-1.1S22 20 21.4 20H2.6c-.6 0-1.1.5-1.1 1.1s.5 1.1 1.1 1.1z"></path>
+                      </g>
+                    </svg>
+                  </span>
+                  <span className="text-[#1b64da] whitespace-nowrap">
+                    문제 등록 양식 다운받기
+                  </span>
+                </button>
+
+                <button
+                  onClick={() => setOpenUploadPracticeProblemsModal('default')}
+                  className="flex justify-center items-center gap-1 text-[0.8rem] bg-[#3183f6] px-3 py-[0.5rem] rounded-[7px] font-medium hover:bg-[#1c6cdb]"
+                >
+                  <span
+                    aria-hidden="false"
+                    role="presentation"
+                    style={{
+                      height: '18px',
+                      width: '18px',
+                      minWidth: '18px',
+                      padding: '0px',
+                    }}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                      <path
+                        fill="white"
+                        d="M12.766 6.604a1.108 1.108 0 00-1.198-.237 1.113 1.113 0 00-.358.237L5.504 12.31a1.1 1.1 0 001.555 1.556l3.829-3.83v11.345a1.1 1.1 0 002.2 0V10.038l3.829 3.829c.215.215.496.322.778.322a1.1 1.1 0 00.778-1.878l-5.707-5.707zM21.38 2.1H2.596a1.1 1.1 0 000 2.2h18.785a1.1 1.1 0 100-2.2"
+                        fillRule="evenodd"
+                      ></path>
+                    </svg>
+                  </span>
+                  <span className="text-white whitespace-nowrap">
+                    문제 한 번에 등록하기
+                  </span>
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {uploadedProblemsInfo.length !== 0 ? (
+          <div>
+            <label
+              {...getRootProps()}
+              className="mt-4 flex justify-between items-center pl-4 pr-2 py-[0.4rem] bg-white border-none outline outline-1 outline-[#e6e8ea] hover:outline-2 hover:outline-[#a3c6fa] hover:outline-offset-[-1px] rounded-[7px] duration-100"
+            >
+              <div className="flex items-center gap-x-2">
+                <span
+                  className="icon p-icon p-menu__item__addon"
+                  aria-hidden="false"
+                  role="presentation"
+                >
+                  <svg
+                    height="20"
+                    width="20"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                  >
+                    <mask id="a" fill="#fff">
+                      <path
+                        d="m0 0h20v19.9996h-20z"
+                        fill="#fff"
+                        fillRule="evenodd"
+                      ></path>
+                    </mask>
+                    <g
+                      fill="#26a06b"
+                      fillRule="evenodd"
+                      transform="translate(2 2)"
+                    >
+                      <path d="m13 14.1719v5.828l7-7h-5.828c-.649 0-1.162.523-1.162 1.162"></path>
+                      <path
+                        d="m5.918 5.6036 1.971 2.893c.061.381-.228.489-.559.489h-.746c-.321-.016-.379-.033-.585-.4l-1.016-1.865-.013-.015-.013.015-1.016 1.865c-.206.367-.264.384-.585.4h-.746c-.331 0-.62-.108-.559-.489l1.971-2.893.001-.001-.038-.044-1.9-2.82c-.15-.217.122-.517.502-.517h.746c.331 0 .372.043.538.315l1.084 1.926.015.018.015-.018 1.084-1.926c.166-.272.207-.315.538-.315h.746c.38 0 .652.3.503.517l-1.901 2.82-.038.044zm12.9-5.604h-17.636c-.654 0-1.182.528-1.182 1.182v17.647c0 .654.528 1.171 1.172 1.171h10.005v-5.878c0-1.626 1.319-2.945 2.944-2.945h5.879v-9.995c0-.654-.528-1.182-1.182-1.182z"
+                        mask="url(#a)"
+                      ></path>
+                    </g>
+                  </svg>
+                </span>
+
+                <span className="text-[15px] text-[#4e5968]">
+                  {excelFileName}
+                </span>
+              </div>
+
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setUploadedProblemsInfo([]);
+                }}
+                className="flex justify-center items-center gap-[0.375rem] text-[13px] text-[#4e5968] bg-[#f2f4f6] px-3 py-1 rounded-[6px] font-light focus:bg-[#d3d6da] hover:bg-[#e6e8ea]"
+              >
+                삭제
+              </button>
+            </label>
+
+            <div className="mt-10">
+              <div className="flex items-center gap-x-[0.6rem] mb-3">
+                <span className="font-semibold text-[19px] text-[#333d4b]">
+                  등록될 문제
+                </span>
+                <span className="text-[#6d7683] text-[0.825rem] font-light">
+                  {uploadedProblemsInfo.length}개
+                </span>
+              </div>
+
+              <UploadedProblemList
+                problemsInfo={uploadedProblemsInfo}
+                setUploadedProblemsInfo={setUploadedProblemsInfo}
+              />
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="py-2">
+              <div className="flex mt-4 justify-between items-center">
+                <span className="text-[#6d7683] text-[0.825rem] font-light">
+                  총{' '}
+                  <span className="text-[#6d7683]">{problemsInfo.length}</span>
+                  개
+                </span>
+              </div>
+
+              <PracticeProblemList
+                problemsInfo={problemsInfo}
+                setProblemsInfo={setProblemsInfo}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      {openUploadingPracticeProblemsModal && (
+        <UploadingPracticeProblemsModal
+          openUploadingPracticeProblemsModal={
+            openUploadingPracticeProblemsModal
+          }
+          setOpenUploadingPracticeProblemsModal={
+            setOpenUploadingPracticeProblemsModal
+          }
+        />
+      )}
+
+      {openUploadPracticeProblemsModal && (
+        <UploadPracticeProblemsModal
+          setExcelFileName={setExcelFileName}
+          setUploadedProblemsInfo={setUploadedProblemsInfo}
+          excelFileUrl={excelFileUrl}
+          setExcelFileUrl={setExcelFileUrl}
+          isExcelFileUploadingValidFail={isExcelFileUploadingValidFail}
+          setIsExcelFileUploadingValidFail={setIsExcelFileUploadingValidFail}
+          openUploadPracticeProblemsModal={openUploadPracticeProblemsModal}
+          setOpenUploadPracticeProblemsModal={
+            setOpenUploadPracticeProblemsModal
+          }
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
resolve #28 

## Description

관리자 사용자가 대회/시험/연습문제 섹션에 대해서 문제를 개별적으로
등록하는 것이 아니라, 엑셀 파일을 첨부했을 때 엑셀 파일 내 정보를 기반으로
다수의 문제를 일괄적으로 등록시킬 수 있는 기능을 추가하였습니다.

- 추가된 문제 일괄 등록 페이지 화면

<img width="1158" alt="Screenshot 2024-12-12 at 10 58 07 PM" src="https://github.com/user-attachments/assets/6247f558-4da9-40d8-b065-2ab8b8117d12" />