### PR TITLE
feat: 시험 삭제 조건 추가

### DIFF
--- a/judger-frontend/app/contests/[cid]/page.tsx
+++ b/judger-frontend/app/contests/[cid]/page.tsx
@@ -489,7 +489,7 @@ export default function ContestDetail(props: DefaultProps) {
   if (isPending) return <ContestDetailPageLoadingSkeleton />;
 
   return (
-    <div className="mt-6 mb-24 px-1 2lg:px-0 overflow-x-auto">
+    <div className="mt-6 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">

--- a/judger-frontend/app/exams/[eid]/page.tsx
+++ b/judger-frontend/app/exams/[eid]/page.tsx
@@ -274,6 +274,11 @@ export default function ExamDetail(props: DefaultProps) {
     );
     if (!userResponse) return;
 
+    if (currentTime >= examStartTime) {
+      addToast('warning', '시험 시작 후에는 삭제할 수 없어요.');
+      return;
+    }
+
     deleteExamMutation.mutate(eid);
   };
 
@@ -438,7 +443,7 @@ export default function ExamDetail(props: DefaultProps) {
   if (!isConfirmPassword || isPending) return <ExamDetailPageLoadingSkeleton />;
 
   return (
-    <div className="mt-6 mb-24 px-1 2lg:px-0 overflow-x-auto">
+    <div className="mt-6 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">{examInfo.title}</p>

--- a/judger-frontend/app/notices/[nid]/page.tsx
+++ b/judger-frontend/app/notices/[nid]/page.tsx
@@ -107,7 +107,7 @@ export default function NoticeDetail(props: DefaultProps) {
   if (isPending) return <NoticeDetailLoadingSkeleton />;
 
   return (
-    <div className="mt-6 mb-24 px-1 2lg:px-0 overflow-x-auto">
+    <div className="mt-6 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">


### PR DESCRIPTION
resolve #38 

## Description

현재 종료된 시험에 대해서도 게시글 작성자 본인의 경우 삭제 요청 시
시험이 삭제되고 있는데, 잘못된 삭제 요청을 예방하고자 대회 삭제 조건과
동일하게 현재 시각이 시험 시작 시각 이후일 때에는 삭제 요청이 이뤄지지
않도록 조건을 추가했습니다.