### PR TITLE
chore: 대회/시험 시간 표시 UI 배치 변경

### DIFF
--- a/judger-frontend/app/contests/[cid]/page.tsx
+++ b/judger-frontend/app/contests/[cid]/page.tsx
@@ -239,7 +239,7 @@ export default function ContestDetail(props: DefaultProps) {
 
       return (
         <span
-          className={`w-fit flex justify-center items-center gap-2 text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-1 rounded-full font-semibold`}
+          className={`w-fit flex justify-center items-center gap-2 text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-1 rounded-full font-semibold`}
         >
           <Image
             src={normalBellImg}
@@ -492,12 +492,24 @@ export default function ContestDetail(props: DefaultProps) {
     <div className="mt-6 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
-          <p className="text-2xl font-bold tracking-tight">
-            {contestInfo.title}
-          </p>
+          <div className="flex gap-x-2 items-center">
+            <p className="text-2xl font-bold tracking-tight">
+              {contestInfo.title}
+            </p>
+            {timeUntilEnd?.isPast ? (
+              <span
+                className={`w-fit flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#de5257] bg-[#fcefee] px-3 py-1 rounded-full font-semibold`}
+              >
+                종료
+              </span>
+            ) : (
+              <>{renderRemainingTime()}</>
+            )}
+          </div>
+
           <div className="h-fit 3md:h-[2rem] flex flex-col 3md:items-center 3md:flex-row pb-3 gap-1 3md:gap-3 border-b border-gray-300">
             <span className="font-semibold">
-              <span className="3md:hidden text-gray-500">• </span>
+              <span className="3md:hidden text-gray-500">•&nbsp;</span>
               참가신청 기간:&nbsp;
               <span className="font-light">
                 {contestInfo.applyingPeriod ? (
@@ -513,25 +525,15 @@ export default function ContestDetail(props: DefaultProps) {
             </span>
             <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
             <span className="flex items-center font-semibold">
-              <span className="3md:hidden text-gray-500">• </span>
+              <span className="3md:hidden text-gray-500">•&nbsp;</span>
               대회 시간:&nbsp;
               <span className="flex items-center gap-x-2 font-light">
                 {formatDateToYYMMDDHHMM(contestInfo.testPeriod.start)} ~&nbsp;
                 {formatDateToYYMMDDHHMM(contestInfo.testPeriod.end)}&nbsp;
               </span>
             </span>
-            <span>
-              {timeUntilEnd?.isPast && (
-                <span
-                  className={`w-fit flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#de5257] bg-[#fcefee] px-3 py-1 rounded-full font-semibold`}
-                >
-                  종료
-                </span>
-              )}
-            </span>
-            <span>{renderRemainingTime()}</span>
             <span className="ml-0 font-semibold 3md:ml-auto">
-              <span className="3md:hidden text-gray-500">• </span>
+              <span className="3md:hidden text-gray-500">•&nbsp;</span>
               작성자:&nbsp;
               <span className="font-light">{contestInfo.writer.name}</span>
             </span>
@@ -646,15 +648,15 @@ export default function ContestDetail(props: DefaultProps) {
         )}
 
         <div className="mt-8 py-2">
-          <p className="text-2xl font-semibold">참가자</p>
           <div className="flex mt-4 justify-between items-center">
-            <span>
-              신청자 수:&nbsp;
-              <span className="text-red-500">
-                {contestInfo.contestants.length}
+            <div className="mt-4 flex items-center gap-x-[0.6rem]">
+              <span className="font-semibold text-[19px] text-[#333d4b]">
+                신청자
               </span>
-              명
-            </span>
+              <span className="text-[#6d7683] text-[0.825rem] font-light">
+                {contestInfo.contestants.length}명
+              </span>
+            </div>
             <div className="flex gap-3">
               {OPERATOR_ROLES.includes(userInfo.role) && (
                 <button

--- a/judger-frontend/app/contests/[cid]/problems/[problemId]/page.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/[problemId]/page.tsx
@@ -251,7 +251,7 @@ export default function ContestProblemDetail(props: DefaultProps) {
           <div className="flex flex-col 3md:flex-row 3md:justify-between gap-1 3md:gap-3 pb-3 border-b border-gray-300">
             <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3">
               <span className="font-semibold">
-                <span className="3md:hidden text-gray-500">• </span>
+                <span className="3md:hidden text-gray-500">•&nbsp;</span>
                 점수:
                 <span className="font-mono font-light">
                   &nbsp;
@@ -263,7 +263,7 @@ export default function ContestProblemDetail(props: DefaultProps) {
               </span>
               <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
-                <span className="3md:hidden text-gray-500">• </span>
+                <span className="3md:hidden text-gray-500">•&nbsp;</span>
                 시간 제한:
                 <span className="font-mono font-light">
                   &nbsp;
@@ -272,7 +272,7 @@ export default function ContestProblemDetail(props: DefaultProps) {
               </span>
               <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
-                <span className="3md:hidden text-gray-500">• </span>
+                <span className="3md:hidden text-gray-500">•&nbsp;</span>
                 메모리 제한:
                 <span className="font-mono font-light">
                   &nbsp;

--- a/judger-frontend/app/contests/[cid]/problems/page.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/page.tsx
@@ -262,7 +262,7 @@ export default function ContestProblems(props: DefaultProps) {
 
       return (
         <span
-          className={`w-fit flex justify-center items-center gap-2 text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-1 rounded-full font-semibold`}
+          className={`w-fit flex justify-center items-center gap-2 text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-1 rounded-full font-semibold`}
         >
           <Image
             src={normalBellImg}
@@ -353,6 +353,18 @@ export default function ContestProblems(props: DefaultProps) {
             >
               {contestProblemsInfo.title}
             </Link>
+
+            <div className="lift-up">
+              {timeUntilEnd?.isPast ? (
+                <span
+                  className={`w-fit flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#de5257] bg-[#fcefee] px-3 py-1 rounded-full font-semibold`}
+                >
+                  종료
+                </span>
+              ) : (
+                <>{renderRemainingTime()}</>
+              )}
+            </div>
           </div>
 
           <div className="flex flex-col 3md:flex-row justify-between pb-3 border-b border-gray-300">
@@ -458,18 +470,6 @@ export default function ContestProblems(props: DefaultProps) {
                     저장하기
                   </button>
                 )}
-            </div>
-
-            <div className="mt-3 3md:h-[1.5rem]">
-              {timeUntilEnd?.isPast ? (
-                <span
-                  className={`w-fit flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#de5257] bg-[#fcefee] px-3 py-1 rounded-full font-semibold`}
-                >
-                  종료
-                </span>
-              ) : (
-                <>{renderRemainingTime()}</>
-              )}
             </div>
           </div>
 

--- a/judger-frontend/app/exams/[eid]/page.tsx
+++ b/judger-frontend/app/exams/[eid]/page.tsx
@@ -176,7 +176,7 @@ export default function ExamDetail(props: DefaultProps) {
 
       return (
         <span
-          className={`w-fit flex justify-center items-center gap-2 text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-1 rounded-full font-semibold`}
+          className={`w-fit flex justify-center items-center gap-2 text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-1 rounded-full font-semibold`}
         >
           <Image
             src={normalBellImg}
@@ -446,33 +446,36 @@ export default function ExamDetail(props: DefaultProps) {
     <div className="mt-6 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
         <div className="flex flex-col gap-8">
-          <p className="text-2xl font-bold tracking-tight">{examInfo.title}</p>
+          <div className="flex gap-x-2 items-center">
+            <p className="text-2xl font-bold tracking-tight">
+              {examInfo.title}
+            </p>
+            {timeUntilEnd?.isPast ? (
+              <span
+                className={`w-fit flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#de5257] bg-[#fcefee] px-3 py-1 rounded-full font-semibold`}
+              >
+                종료
+              </span>
+            ) : (
+              <>{renderRemainingTime()}</>
+            )}
+          </div>
           <div className="h-fit 3md:h-[2rem] flex flex-col 3md:items-center 3md:flex-row pb-3 gap-1 3md:gap-3 border-b border-gray-300">
             <span className="font-semibold">
-              <span className="3md:hidden text-gray-500">• </span>
+              <span className="3md:hidden text-gray-500">•&nbsp;</span>
               시험 시간:&nbsp;
               <span className="font-light">
                 {formatDateToYYMMDDHHMM(examInfo.testPeriod.start)} ~&nbsp;
                 {formatDateToYYMMDDHHMM(examInfo.testPeriod.end)}&nbsp;
               </span>
             </span>
-            <span>
-              {timeUntilEnd?.isPast && (
-                <span
-                  className={`w-fit flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#de5257] bg-[#fcefee] px-3 py-1 rounded-full font-semibold`}
-                >
-                  종료
-                </span>
-              )}
-            </span>
-            <span>{renderRemainingTime()}</span>
             <span className="ml-0 font-semibold 3md:ml-auto">
-              <span className="3md:hidden text-gray-500">• </span>
+              <span className="3md:hidden text-gray-500">•&nbsp;</span>
               수업명: <span className="font-light">{examInfo.course}</span>
             </span>
             <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
             <span className="font-semibold">
-              <span className="3md:hidden text-gray-500">• </span>
+              <span className="3md:hidden text-gray-500">•&nbsp;</span>
               작성자: <span className="font-light">{examInfo.writer.name}</span>
             </span>
           </div>

--- a/judger-frontend/app/exams/[eid]/problems/[problemId]/page.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/[problemId]/page.tsx
@@ -176,7 +176,7 @@ export default function ExamProblemDetail(props: DefaultProps) {
           <div className="flex flex-col 3md:flex-row 3md:justify-between gap-1 3md:gap-3 pb-3 border-b border-gray-300">
             <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3">
               <span className="font-semibold">
-                <span className="3md:hidden text-gray-500">• </span>
+                <span className="3md:hidden text-gray-500">•&nbsp;</span>
                 시간 제한:
                 <span className="font-mono font-light">
                   &nbsp;
@@ -185,7 +185,7 @@ export default function ExamProblemDetail(props: DefaultProps) {
               </span>
               <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
-                <span className="3md:hidden text-gray-500">• </span>
+                <span className="3md:hidden text-gray-500">•&nbsp;</span>
                 메모리 제한:
                 <span className="font-mono font-light">
                   &nbsp;

--- a/judger-frontend/app/exams/[eid]/problems/page.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/page.tsx
@@ -84,7 +84,6 @@ export default function ExamProblems(props: DefaultProps) {
   const updateUserInfo = userInfoStore((state: any) => state.updateUserInfo);
 
   const [isLoading, setIsLoading] = useState(true);
-  const [title, setTitle] = useState('');
   const [problemsInfo, setProblemsInfo] = useState<ProblemInfo[]>([]);
 
   const timeUntilStart = useCountdownTimer(examProblemsInfo?.testPeriod.start);
@@ -104,7 +103,6 @@ export default function ExamProblems(props: DefaultProps) {
 
   useEffect(() => {
     if (examProblemsInfo) {
-      setTitle(examProblemsInfo.title);
       setProblemsInfo(examProblemsInfo.problems);
     }
   }, [examProblemsInfo]);
@@ -181,7 +179,7 @@ export default function ExamProblems(props: DefaultProps) {
 
       return (
         <span
-          className={`w-fit flex justify-center items-center gap-2 text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-1 rounded-full font-semibold`}
+          className={`w-fit flex justify-center items-center gap-2 text-[0.8rem] text-[#4e5968] bg-[#f2f4f6] px-3 py-1 rounded-full font-semibold`}
         >
           <Image
             src={normalBellImg}
@@ -273,8 +271,20 @@ export default function ExamProblems(props: DefaultProps) {
               href={`/exams/${eid}`}
               className="lift-up w-fit flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#487fee] bg-[#e8f3ff] px-3 py-1 rounded-full font-semibold hover:bg-[#cee1fc]"
             >
-              {title}
+              {examProblemsInfo.title}
             </Link>
+
+            <div className="lift-up">
+              {timeUntilEnd?.isPast ? (
+                <span
+                  className={`w-fit flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#de5257] bg-[#fcefee] px-3 py-1 rounded-full font-semibold`}
+                >
+                  종료
+                </span>
+              ) : (
+                <>{renderRemainingTime()}</>
+              )}
+            </div>
           </div>
 
           <div className="flex flex-col 3md:flex-row justify-between pb-3 border-b border-gray-300">
@@ -354,18 +364,6 @@ export default function ExamProblems(props: DefaultProps) {
                       </button>
                     )}
                 </>
-              )}
-            </div>
-
-            <div className="mt-3 3md:h-[1.5rem]">
-              {timeUntilEnd?.isPast ? (
-                <span
-                  className={`w-fit flex justify-center items-center gap-[0.375rem] text-[0.8rem] text-[#de5257] bg-[#fcefee] px-3 py-1 rounded-full font-semibold`}
-                >
-                  종료
-                </span>
-              ) : (
-                <>{renderRemainingTime()}</>
               )}
             </div>
           </div>

--- a/judger-frontend/app/practices/[pid]/page.tsx
+++ b/judger-frontend/app/practices/[pid]/page.tsx
@@ -132,7 +132,7 @@ export default function PracticeProblem(props: DefaultProps) {
           <div className="flex flex-col 3md:flex-row 3md:justify-between gap-1 3md:gap-3 pb-3 border-b border-gray-300">
             <div className="flex flex-col 3md:flex-row gap-1 3md:gap-3">
               <span className="font-semibold">
-                <span className="3md:hidden text-gray-500">• </span>
+                <span className="3md:hidden text-gray-500">•&nbsp;</span>
                 시간 제한:&nbsp;
                 <span className="font-mono font-light">
                   {practiceProblemInfo.options.maxRealTime / 1000}초
@@ -140,7 +140,7 @@ export default function PracticeProblem(props: DefaultProps) {
               </span>
               <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
-                <span className="3md:hidden text-gray-500">• </span>
+                <span className="3md:hidden text-gray-500">•&nbsp;</span>
                 메모리 제한:&nbsp;
                 <span className="font-mono font-light">
                   <span className="mr-1">
@@ -151,7 +151,7 @@ export default function PracticeProblem(props: DefaultProps) {
               </span>
               <span className='hidden relative bottom-[0.055rem] font-thin before:content-["|"] 3md:block' />
               <span className="font-semibold">
-                <span className="3md:hidden text-gray-500">• </span>
+                <span className="3md:hidden text-gray-500">•&nbsp;</span>
                 난이도:&nbsp;
                 <span className="font-mono font-light">
                   <span className="mr-1 font-mono font-semibold text-blue-600">
@@ -162,7 +162,7 @@ export default function PracticeProblem(props: DefaultProps) {
             </div>
             <div className="flex gap-3">
               <span className="font-semibold">
-                <span className="3md:hidden text-gray-500">• </span>
+                <span className="3md:hidden text-gray-500">•&nbsp;</span>
                 작성자:&nbsp;
                 <span className="font-light">
                   {practiceProblemInfo.writer.name}


### PR DESCRIPTION
resolve #44 

## Description

대회/시험 시작 및 종료시간까지 남은 시간을 표시해 주던 타이머 UI를
`title` 우측으로 일괄 배치하고자 하였습니다.