### PR TITLE
chore: 게시글 상세 페이지 동적 너비 스타일 수정

### DIFF
--- a/judger-frontend/app/contests/[cid]/page.tsx
+++ b/judger-frontend/app/contests/[cid]/page.tsx
@@ -490,7 +490,7 @@ export default function ContestDetail(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <div className="flex gap-x-2 items-center">
             <p className="text-2xl font-bold tracking-tight">

--- a/judger-frontend/app/contests/[cid]/problems/[problemId]/page.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/[problemId]/page.tsx
@@ -243,7 +243,7 @@ export default function ContestProblemDetail(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">
             {contestProblemInfo.title}

--- a/judger-frontend/app/contests/[cid]/problems/page.tsx
+++ b/judger-frontend/app/contests/[cid]/problems/page.tsx
@@ -327,7 +327,7 @@ export default function ContestProblems(props: DefaultProps) {
 
   return (
     <div className="mt-4 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <div className="flex items-center gap-x-2">
             <div className="flex items-center text-2xl font-bold tracking-tight">

--- a/judger-frontend/app/contests/[cid]/ranklist/page.tsx
+++ b/judger-frontend/app/contests/[cid]/ranklist/page.tsx
@@ -189,7 +189,7 @@ export default function ContestRankList(props: DefaultProps) {
 
   return (
     <div className="mt-4 mb-24 px-1 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <div className="flex justify-between">
             <div className="flex 3md:flex-row flex-col 3md:items-center gap-2">

--- a/judger-frontend/app/exams/[eid]/page.tsx
+++ b/judger-frontend/app/exams/[eid]/page.tsx
@@ -444,7 +444,7 @@ export default function ExamDetail(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <div className="flex gap-x-2 items-center">
             <p className="text-2xl font-bold tracking-tight">

--- a/judger-frontend/app/exams/[eid]/problems/[problemId]/page.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/[problemId]/page.tsx
@@ -168,7 +168,7 @@ export default function ExamProblemDetail(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">
             {examProblemInfo.title}

--- a/judger-frontend/app/exams/[eid]/problems/page.tsx
+++ b/judger-frontend/app/exams/[eid]/problems/page.tsx
@@ -248,7 +248,7 @@ export default function ExamProblems(props: DefaultProps) {
 
   return (
     <div className="mt-4 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <div className="flex items-center gap-x-2">
             <div className="flex items-center text-2xl font-bold tracking-tight">

--- a/judger-frontend/app/notices/[nid]/page.tsx
+++ b/judger-frontend/app/notices/[nid]/page.tsx
@@ -108,7 +108,7 @@ export default function NoticeDetail(props: DefaultProps) {
 
   return (
     <div className="mt-6 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">
             {noticeInfo.title}

--- a/judger-frontend/app/practices/[pid]/page.tsx
+++ b/judger-frontend/app/practices/[pid]/page.tsx
@@ -124,7 +124,7 @@ export default function PracticeProblem(props: DefaultProps) {
 
   return (
     <div className="relative mt-6 mb-24 px-5 2lg:px-0 overflow-x-auto">
-      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[72.5%] mx-auto">
+      <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
         <div className="flex flex-col gap-8">
           <p className="text-2xl font-bold tracking-tight">
             {practiceProblemInfo.title}


### PR DESCRIPTION
resolve #49 

## Description

게시글 상세 페이지 너비를 설정하는 Tailwind CSS className을
Navbar 및 Footer와 동일하게 설정되도록 수정했습니다.

- 수정 전 게시글 본문 너비

<img width="1107" alt="Screenshot 2024-12-23 at 8 15 00 PM" src="https://github.com/user-attachments/assets/20094c93-2ad6-4a26-afd7-c6a2900f0375" />

- 수정 후 게시글 본문 너비

<img width="1107" alt="Screenshot 2024-12-23 at 8 15 43 PM" src="https://github.com/user-attachments/assets/5eecf1e7-69fb-46b3-8741-3840555d2797" />