### PR TITLE
fix: Pagination 컴포넌트 내 warning 제거

### DIFF
--- a/judger-frontend/app/components/PaginationNav.tsx
+++ b/judger-frontend/app/components/PaginationNav.tsx
@@ -58,14 +58,14 @@ export default function PaginationNav({
               </svg>
             </button>
           </li>
-          <li className="flex items-center gap-x-[0.35rem] order-1 3xs:order-2">
+          <div className="flex items-center gap-x-[0.35rem] order-1 3xs:order-2">
             {RenderPaginationButtons(
               page,
               totalPages,
               handlePagination,
               isSmallScreen,
             )}
-          </li>
+          </div>
         </div>
         <li>
           <button
@@ -78,7 +78,6 @@ export default function PaginationNav({
             disabled={page >= totalPages}
           >
             <svg
-              enable-background="new 0 0 24 24"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
               className="scale-125"

--- a/judger-frontend/app/practices/[pid]/edit/page.tsx
+++ b/judger-frontend/app/practices/[pid]/edit/page.tsx
@@ -106,8 +106,6 @@ export default function EditPractice(props: DefaultProps) {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [isOpenSearchedResultList, setIsOpenSearchedResultList] =
     useState<boolean>(false);
-  const [isSuccessSearchResult, setIsSuccessSearchResult] =
-    useState<boolean>(false);
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
   useState<boolean>(false);
 


### PR DESCRIPTION
resolve #67 

## Description

Pagination 요소 렌더링을 담당하는 `PaginationNav` 컴포넌트 내에서
잘못 구성된 `<li>` 태그로 인해 발생하던 `warning`을 제거하였습니다.

> [!WARNING]
> app-index.js:32 Warning: validateDOMNesting(...): `<li> cannot appear as a descendant of <li>`