### PR TITLE
fix: Safari Webview 내 Pagination 버튼 svg 요소 표시 불가 크로싱브라우저 이슈

### DIFF
--- a/judger-frontend/app/components/Navbar.tsx
+++ b/judger-frontend/app/components/Navbar.tsx
@@ -141,7 +141,9 @@ export default function Navbar() {
       ref={navbarRef}
       className={`w-screen h-[3.25rem] flex items-center z-30 2lg:p-0 py-2 pl-4 pr-0 fixed top-0 whitespace-nowrap ${
         isScrolled || !isHomePage
-          ? 'border-b border-[#e6e8ea] bg-white'
+          ? isScrolled
+            ? 'border-b border-[#e6e8ea] bg-white'
+            : 'bg-white'
           : 'bg-[#191f28] 2md:bg-transparent'
       }`}
     >
@@ -181,7 +183,7 @@ export default function Navbar() {
             >
               <Link
                 href="/contests"
-                className={`$${
+                className={`${
                   currentPathKeyword === 'contests' && 'font-semibold'
                 } ${
                   isScrolled || !isHomePage
@@ -193,7 +195,7 @@ export default function Navbar() {
               </Link>
               <Link
                 href="/exams"
-                className={`$${
+                className={`${
                   currentPathKeyword === 'exams' && 'font-semibold'
                 } ${
                   isScrolled || !isHomePage
@@ -205,7 +207,7 @@ export default function Navbar() {
               </Link>
               <Link
                 href="/practices"
-                className={`$${
+                className={`${
                   currentPathKeyword === 'practices' && 'font-semibold'
                 } ${
                   isScrolled || !isHomePage
@@ -217,7 +219,7 @@ export default function Navbar() {
               </Link>
               <Link
                 href="/notices"
-                className={`$${
+                className={`${
                   currentPathKeyword === 'notices' && 'font-semibold'
                 } ${
                   isScrolled || !isHomePage
@@ -240,7 +242,7 @@ export default function Navbar() {
               <>
                 <Link
                   href="/mypage/profile"
-                  className={`$${
+                  className={`${
                     currentPathKeyword === 'mypage' && 'font-semibold'
                   } px-3 py-2 rounded-md ${
                     isScrolled || !isHomePage

--- a/judger-frontend/app/components/PaginationNav.tsx
+++ b/judger-frontend/app/components/PaginationNav.tsx
@@ -48,6 +48,8 @@ export default function PaginationNav({
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
+                width={24}
+                height={24}
                 viewBox="0 0 24 24"
                 className="scale-125"
               >
@@ -78,8 +80,10 @@ export default function PaginationNav({
             disabled={page >= totalPages}
           >
             <svg
-              viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
+              width={24}
+              height={24}
+              viewBox="0 0 24 24"
               className="scale-125"
             >
               <path


### PR DESCRIPTION
resolve #74 

## Description

`Safari Webview` 페이지 내에서 Pagination 버튼 내부
svg 요소가 그려지지 않는 이슈가 발견되어 이를 해결하고자
했습니다.

- `Safari Webview` 페이지 내 화살표 svg 요소가 화면에 그려지지 않음

<img width="479" alt="Screenshot 2025-01-04 at 1 59 55 PM" src="https://github.com/user-attachments/assets/9e0cc9a7-278d-4956-9fe0-57f21f4076ec" />

- 해결 후

<img width="479" alt="Screenshot 2025-01-04 at 2 00 59 PM" src="https://github.com/user-attachments/assets/7cf878d3-7693-42c4-ac8f-7d23d51a7199" />