### PR TITLE
feat: GitHub Actions CI/CD를 위한 워크플로우 정의 파일 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,72 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.17.0'
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./judger-frontend
+
+      - name: Run lint
+        run: npm run lint
+        working-directory: ./judger-frontend
+
+      # - name: Run tests
+      #   run: npm test
+      #   working-directory: ./judger-frontend
+
+  cd:
+    name: Continuous Deployment
+    needs: ci
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: SSH Remote Commands
+        uses: appleboy/ssh-action@v0.1.4
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          timeout: 40s
+          script: |
+            echo "#START"
+            cd /home/soft1/prod_2022/sw-judger
+
+            echo "############# GIT PULL #############"
+            if git pull origin main; then
+              echo "Git pull successful"
+            else
+              echo "Git pull failed!"
+              exit 1
+            fi
+
+            echo "############# DOCKER-COMPOSE DOWN #############"
+            docker-compose -f docker-compose_prod.yml down --remove-orphans || { echo "Failed to stop existing containers"; exit 1; }
+
+            echo "############# DOCKER SYSTEM AND VOLUME PRUNE #############"
+            docker system prune -f || { echo "Failed to prune Docker system!"; }
+            docker volume prune -f || { echo "Failed to prune Docker volumes!"; }
+
+            echo "############# DOCKER-COMPOSE UP #############"
+            docker-compose -f docker-compose_prod.yml up -d --build --remove-orphans || { echo "Failed to build and start Docker Compose! Exiting."; exit 1; }

--- a/judger-frontend/.dockerignore
+++ b/judger-frontend/.dockerignore
@@ -1,2 +1,7 @@
 node_modules
 ckeditor5-custom-build
+dist
+.git
+*.log
+.env
+uploads


### PR DESCRIPTION
resolve #78 

## Description

PR을 통한 `main` 브랜치 내 작업 커밋이 추가된 후에 실제 배포 중인 서버에 반영하려면,
ssh 원격 접속을 통해 사전에 작성해 둔 `deploy_shell` 파일을 직접 실행해서 배포를 진행하였는데,
매번 해당 작업을 반복하는 것이 비효율적인 시간 소비 및 공수라고 판단하여 GitHub Actions CI/CD
프로세스 자동화 목적의 워크플로우를 도입해 해당 이슈를 해결했습니다.