### PR TITLE
chore: 로그인 페이지 내 비밀번호 입력란 폰트 크기 조정

### DIFF
--- a/judger-frontend/app/login/page.tsx
+++ b/judger-frontend/app/login/page.tsx
@@ -254,7 +254,7 @@ export default function Login() {
                   });
                 }}
                 onBlur={verifyPwdInputValueValidFail}
-                className={`h-[2.5rem] text-lg tracking-[0.01em] text-[rgba(0,12,30,0.75)] font-light flex items-center rounded-[7px] duration-100 px-[0.825rem] ${
+                className={`h-[2.5rem] text-[0.875rem] tracking-[0.01em] text-[rgba(0,12,30,0.75)] font-light flex items-center rounded-[7px] duration-100 px-[0.825rem] ${
                   isPwdInputValidFail
                     ? STR_WRONG_CASE_INPUT_ELEMENT_STYLE_CLASSNAME
                     : STR_RIGHT_CASE_INPUT_ELEMENT_STYLE_CLASSNAME


### PR DESCRIPTION
resolve #96 

## Description

서비스 폰트 일괄 변경 후, 서비스 로그인 페이지 내 비밀번호 입력란의 폰트 크기가
초기 디자인보다 커지는 이슈가 발견되어 적정 사이즈로 조정하고자 하였습니다.

- 수정 전, 비밀번호 입력란 폰트 크기

<img width="498" alt="Screenshot 2025-01-25 at 11 38 53 AM" src="https://github.com/user-attachments/assets/489e096e-96cf-47d2-b018-8f4fd6e104c5" />

- 수정 후, 비밀번호 입력란 폰트 크기

<img width="498" alt="Screenshot 2025-01-25 at 11 40 05 AM" src="https://github.com/user-attachments/assets/660bebf5-aa29-49d8-9787-2adcb1edaaa7" />