### PR TITLE
chore: 연습문제 목록 페이지 UI 변경

### DIFF
--- a/judger-frontend/app/practices/components/EmptyPracticeListItem.tsx
+++ b/judger-frontend/app/practices/components/EmptyPracticeListItem.tsx
@@ -1,15 +1,6 @@
+import NotFound from '@/app/components/NotFound';
 import React from 'react';
 
 export default function EmptyPracticeListItem() {
-  return (
-    <tr className="h-[2.5rem] border-b-[1.25px] border-[#d1d6db] text-xs text-center">
-      <th
-        scope="row"
-        className="px-2 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
-      >
-        1
-      </th>
-      <td className="text-[#4e5968]">등록된 연습문제 정보가 없어요</td>
-    </tr>
-  );
+  return <NotFound message={'조회 가능한 문제 정보가 없어요'} />;
 }

--- a/judger-frontend/app/practices/components/PracticeList.tsx
+++ b/judger-frontend/app/practices/components/PracticeList.tsx
@@ -77,63 +77,27 @@ export default function PracticeList({ searchQuery }: PracticeListProps) {
     <div className="mx-auto w-full">
       <div className="relative overflow-hidden rounded-sm">
         <div className="overflow-x-auto">
-          <table className="w-[60rem] 3xs:w-full text-sm text-left text-gray-500">
-            <thead className="border-y-[1.25px] border-[#d1d6db] text-xs uppercase bg-[#f2f4f6] text-center">
-              <tr className="h-[2rem]">
-                <th
-                  scope="col"
-                  className="font-medium text-[#333d4b] w-16 px-4 py-2 hover:bg-[#e6e8eb]"
-                >
-                  번호
-                </th>
-                <th
-                  scope="col"
-                  className="font-medium text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
-                >
-                  문제명
-                </th>
-                <th
-                  scope="col"
-                  className="font-medium text-[#333d4b] w-16 px-4 py-2 hover:bg-[#e6e8eb]"
-                >
-                  난이도
-                </th>
-                <th
-                  scope="col"
-                  className="font-medium text-[#333d4b] w-32 px-4 py-2 hover:bg-[#e6e8eb]"
-                >
-                  작성자
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {resData?.documents.length === 0 ? (
-                <EmptyPracticeListItem />
-              ) : (
-                <>
-                  {resData?.documents.map(
-                    (practiceInfo: ProblemInfo, index: number) => (
-                      <PracticeListItem
-                        practiceInfo={practiceInfo}
-                        total={resData.total}
-                        page={page}
-                        index={index}
-                        key={index}
-                      />
-                    ),
-                  )}
-                </>
-              )}
-            </tbody>
-          </table>
+          {resData?.documents.length === 0 ? (
+            <EmptyPracticeListItem />
+          ) : (
+            <>
+              <div className="flex flex-col gap-4">
+                {resData?.documents.map(
+                  (practiceInfo: ProblemInfo, index: number) => (
+                    <PracticeListItem
+                      practiceInfo={practiceInfo}
+                      total={resData.total}
+                      page={page}
+                      index={index}
+                      key={index}
+                    />
+                  ),
+                )}
+              </div>
+            </>
+          )}
         </div>
       </div>
-
-      <PaginationNav
-        page={page}
-        totalPages={totalPages}
-        handlePagination={handlePagination}
-      />
     </div>
   );
 }

--- a/judger-frontend/app/practices/components/PracticeListItem.tsx
+++ b/judger-frontend/app/practices/components/PracticeListItem.tsx
@@ -1,4 +1,5 @@
 import { ProblemInfo } from '@/types/problem';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -15,21 +16,16 @@ export default function PracticeListItem(props: PracticeListItemProps) {
   const router = useRouter();
 
   return (
-    <tr
-      className="h-[2.5rem] border-b-[1.25px] border-[#d1d6db] text-xs text-center cursor-pointer hover:bg-[#e8f3ff]"
-      onClick={() => router.push(`practices/${practiceInfo._id}`)}
+    <Link
+      href={`practices/${practiceInfo._id}`}
+      className="flex items-center gap-2 w-full px-3 py-[0.6rem] cursor-pointer bg-[#f2f4f6] hover:bg-[#d3d6da] rounded-[7px]"
     >
-      <th
-        scope="row"
-        className="px-2 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
-      >
-        {total - (page - 1) * 10 - index}
-      </th>
-      <td className="px-2 font-semibold text-[#4e5968]">
+      <span className="flex justify-center items-center font-medium bg-[#8c95a0] text-[14px] text-white w-5 h-5 rounded-[7px]">
+        {String.fromCharCode('A'.charCodeAt(0) + index)}
+      </span>
+      <span className="px-2 font-semibold text-[#4e5968]">
         {practiceInfo.title}
-      </td>
-      <td className="px-2 text-[#4e5968]">{practiceInfo.score}</td>
-      <td className="px-2 text-[#4e5968]">{practiceInfo.writer.name}</td>
-    </tr>
+      </span>
+    </Link>
   );
 }

--- a/judger-frontend/app/practices/page.tsx
+++ b/judger-frontend/app/practices/page.tsx
@@ -59,7 +59,7 @@ export default function Practices() {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className="w-full h-[2.3rem] pl-[0.625rem] pr-[0.25rem] outline-none placeholder-[#888e96] text-[0.825rem] font-extralight"
-                  placeholder="문제명, 작성자명으로 검색"
+                  placeholder="문제명으로 검색"
                 />
               </div>
               {searchQuery && (
@@ -129,7 +129,7 @@ export default function Practices() {
         </div>
 
         {isInitialized && (
-          <section className="dark:bg-gray-900">
+          <section className="mt-6">
             <PracticeList searchQuery={searchQuery} />
           </section>
         )}

--- a/judger-frontend/postcss.config.js
+++ b/judger-frontend/postcss.config.js
@@ -3,4 +3,4 @@ module.exports = {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};


### PR DESCRIPTION
resolve #98 

## Description

연습문제 목록 페이지 UI를 대회 및 시험 문제 목록 페이지 UI와 동일하게
변경하여 디자인 통일성을 가질 수 있도록 합니다.

- 수정 전, 연습문제 페이지 UI

<img width="1131" alt="Screenshot 2025-02-01 at 2 03 21 PM" src="https://github.com/user-attachments/assets/b86c8c92-1c5f-487a-9bd7-d93eea89ca35" />

- 수정 후, 연습문제 페이지 UI

<img width="1131" alt="Screenshot 2025-02-01 at 2 43 19 PM" src="https://github.com/user-attachments/assets/8e975850-6fc6-42de-b099-caf079df6b6e" />