### PR TITLE
chore: Navbar 컴포넌트 UI 변경

### DIFF
--- a/judger-frontend/app/components/Navbar.tsx
+++ b/judger-frontend/app/components/Navbar.tsx
@@ -139,13 +139,15 @@ export default function Navbar() {
   return (
     <nav
       ref={navbarRef}
-      className={`w-screen h-[3.25rem] flex items-center z-30 2lg:p-0 py-2 pl-4 pr-0 fixed top-0 whitespace-nowrap ${
+      className={`w-screen h-[3.25rem] flex items-center z-30 2lg:p-0 py-2 pl-4 pr-0 fixed top-0 whitespace-nowrap
+      ${
         isScrolled || !isHomePage
           ? isScrolled
-            ? 'border-b border-[#e6e8ea] bg-white'
-            : 'bg-white'
+            ? 'border-b border-[#001b37] border-opacity-10 bg-white bg-opacity-50 backdrop-blur-md'
+            : 'bg-white backdrop-blur-sm'
           : 'bg-[#191f28] 2md:bg-transparent'
-      }`}
+      }
+    `}
     >
       <div className="2lg:w-[61rem] w-full flex justify-between items-center mx-auto">
         <div className="py-2 2md:py-0 z-20">
@@ -187,7 +189,7 @@ export default function Navbar() {
                   currentPathKeyword === 'contests' && 'font-semibold'
                 } ${
                   isScrolled || !isHomePage
-                    ? 'hover:bg-[#f3f4f5] hover:text-[#0057b3]'
+                    ? 'hover:bg-[#022047] hover:bg-opacity-5 hover:text-[#0057b3]'
                     : 'hover:bg-[#22262a]'
                 } px-3 py-2 rounded-md`}
               >
@@ -199,7 +201,7 @@ export default function Navbar() {
                   currentPathKeyword === 'exams' && 'font-semibold'
                 } ${
                   isScrolled || !isHomePage
-                    ? 'hover:bg-[#f3f4f5] hover:text-[#0057b3]'
+                    ? 'hover:bg-[#022047] hover:bg-opacity-5 hover:text-[#0057b3]'
                     : 'hover:bg-[#22262a]'
                 } px-3 py-2 rounded-md`}
               >
@@ -211,7 +213,7 @@ export default function Navbar() {
                   currentPathKeyword === 'practices' && 'font-semibold'
                 } ${
                   isScrolled || !isHomePage
-                    ? 'hover:bg-[#f3f4f5] hover:text-[#0057b3]'
+                    ? 'hover:bg-[#022047] hover:bg-opacity-5 hover:text-[#0057b3]'
                     : 'hover:bg-[#22262a]'
                 } px-3 py-2 rounded-md`}
               >
@@ -223,7 +225,7 @@ export default function Navbar() {
                   currentPathKeyword === 'notices' && 'font-semibold'
                 } ${
                   isScrolled || !isHomePage
-                    ? 'hover:bg-[#f3f4f5] hover:text-[#0057b3]'
+                    ? 'hover:bg-[#022047] hover:bg-opacity-5 hover:text-[#0057b3]'
                     : 'hover:bg-[#22262a]'
                 } px-3 py-2 rounded-md`}
               >


### PR DESCRIPTION
resolve #100 

## Description

Navbar 컴포넌트의 UI를 투명하게 변경하여 기존의 스타일에 투명도를 적용하여
배경에 가려지던 뒷 배경 내 요소를 blur 상태로 흐릿하게 보일 수 있도록 디자인을
변경하고자 하였습니다.

- 수정 전 Navbar 컴포넌트 UI

<img width="1131" alt="Screenshot 2025-02-01 at 8 06 54 PM" src="https://github.com/user-attachments/assets/1277de80-f571-4b98-b8db-9f9a015a980f" />

- 수정 후 Navbar 컴포넌트 UI

<img width="1131" alt="Screenshot 2025-02-01 at 7 58 12 PM" src="https://github.com/user-attachments/assets/7687ddc8-28af-4cb2-ba06-8f0668fe55ed" />