### PR TITLE
chore: 공지사항 페이지 UI 변경

### DIFF
--- a/judger-frontend/app/globals.css
+++ b/judger-frontend/app/globals.css
@@ -11,6 +11,8 @@
   font-family: 'Toss Product Sans', -apple-system, BlinkMacSystemFont,
     'Apple SD Gothic Neo', Pretendard, Roboto, 'Noto Sans KR', 'Segoe UI',
     'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 .sub-navbar {
@@ -336,10 +338,6 @@
   background-color: #fafafa !important;
 }
 
-.ck {
-  letter-spacing: 0.005rem;
-}
-
 .ck strong {
   color: inherit;
 }
@@ -365,17 +363,23 @@
   font-size: 1.25em;
 }
 
-.markdown-preview strong,
-.markdown-preview s,
-.markdown-preview u,
-.markdown-preview i {
-  color: inherit;
+.ck figure {
+  margin: 0 !important;
 }
 
 .ck ul,
 .ck ol {
   margin-left: 1.75rem;
   margin-top: 0.25rem !important;
+}
+
+.ck li::marker {
+  font-size: 0.5em;
+  color: #4e5968;
+}
+
+.ck li {
+  padding-left: 0.3rem !important;
 }
 
 .ck blockquote {
@@ -387,7 +391,13 @@
 }
 
 .ck p {
-  margin-bottom: 0 !important;
+  margin-bottom: 16px !important;
+  color: #4e5968;
+}
+
+.ck figcaption {
+  font-size: 16px !important;
+  color: #4e5968 !important;
 }
 
 .ck .text-huge,
@@ -415,13 +425,26 @@
 
 .markdown-preview {
   background-color: white !important;
-  letter-spacing: 0.04rem;
+}
+
+.markdown-preview figcaption {
+  padding: 0.375rem;
+  color: #4e5968;
+  background-color: #f7f7f7;
+  text-align: center;
+}
+
+.markdown-preview strong,
+.markdown-preview s,
+.markdown-preview u,
+.markdown-preview i {
+  color: inherit;
 }
 
 .markdown-preview figure {
+  width: fit-content;
   margin-left: 0 !important;
   margin-right: 0 !important;
-  width: 100% !important;
 }
 
 .markdown-preview tr:nth-child(odd) {
@@ -431,12 +454,17 @@
 .markdown-preview tr:nth-child(even) {
   background-color: #f7f9fc !important;
 }
-
-.markdown-preview td {
+ㅑ .markdown-preview td {
   border-color: #d4d6da !important;
 }
-.markdown-preview p {
+
+.markdown-preview td > p {
   margin-bottom: 0 !important;
+}
+
+.markdown-preview p {
+  color: #4e5968;
+  margin-bottom: 16px;
 }
 
 .markdown-preview strong,
@@ -444,6 +472,10 @@
 .markdown-preview u,
 .markdown-preview i {
   color: inherit;
+}
+
+.markdown-preview strong {
+  font-weight: 700 !important;
 }
 
 .markdown-preview .text-huge {
@@ -473,6 +505,15 @@
 
 .markdown-preview ol {
   list-style-type: disc;
+}
+
+.markdown-preview li::marker {
+  font-size: 0.5em;
+  color: #4e5968;
+}
+
+.markdown-preview li {
+  padding-left: 0.3rem !important;
 }
 
 .markdown-preview blockquote {

--- a/judger-frontend/app/notices/[nid]/page.tsx
+++ b/judger-frontend/app/notices/[nid]/page.tsx
@@ -4,7 +4,10 @@ import { OPERATOR_ROLES } from '@/constants/role';
 import { userInfoStore } from '@/store/UserInfo';
 import { NoticeInfo } from '@/types/notice';
 import axiosInstance from '@/utils/axiosInstance';
-import { formatDateToYYMMDDHHMM } from '@/utils/formatDate';
+import {
+  formatDateToYYMMDDHHMM,
+  formatDateToYYMMDDWithDot,
+} from '@/utils/formatDate';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import dynamic from 'next/dynamic';
@@ -106,30 +109,27 @@ export default function NoticeDetail(props: DefaultProps) {
   if (isPending) return <NoticeDetailLoadingSkeleton />;
 
   return (
-    <div className="mt-6 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
+    <div className="mt-10 mb-24 px-1 pb-1 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
-        <div className="flex flex-col gap-8">
-          <p className="text-2xl font-bold tracking-tight">
-            {noticeInfo.title}
+        <div className="flex flex-col gap-2">
+          <p className="h-16 flex items-center text-[42px] font-bold tracking-wide">
+            <span className="lift-up">공지사항</span>
           </p>
 
-          <div className="h-fit 3md:h-[2rem] flex flex-col 3md:items-center 3md:flex-row pb-3 gap-1 3md:gap-3 border-b border-gray-300">
+          <td className="mt-7 font-semibold text-[#4e5968] text-[24px] leading-[2rem]">
+            {noticeInfo.title}
+          </td>
+
+          <div className="flex flex-col 3md:items-center 3md:flex-row pb-6 gap-1 3md:gap-3 border-b border-[#e5e8eb]">
             <span className="font-semibold">
-              <span className="3md:hidden text-gray-500">•&nbsp;</span>
-              작성일:&nbsp;
-              <span className="font-light">
-                {formatDateToYYMMDDHHMM(noticeInfo.createdAt)}
-              </span>
-            </span>
-            <span className="ml-0 font-semibold 3md:ml-auto">
-              <span className="3md:hidden text-gray-500">•&nbsp;</span>
-              작성자:&nbsp;
-              <span className="font-light">{noticeInfo.writer.name}</span>
+              <td className="text-[#8b95a1] text-[14px] font-extralight">
+                {formatDateToYYMMDDWithDot(noticeInfo.createdAt)}
+              </td>
             </span>
           </div>
         </div>
 
-        <div className="border-b mt-8 mb-4 pb-5">
+        <div className="border-b border-[#e5e8eb] mt-9 mb-4 pb-10">
           <MarkdownPreview
             className="markdown-preview"
             source={noticeInfo.content}

--- a/judger-frontend/app/notices/components/NoticeList.tsx
+++ b/judger-frontend/app/notices/components/NoticeList.tsx
@@ -76,63 +76,35 @@ export default function NoticeList({ searchQuery }: NoticeListProps) {
     <div className="mx-auto w-full">
       <div className="relative overflow-hidden rounded-sm">
         <div className="overflow-x-auto">
-          <table className="w-[60rem] 3xs:w-full text-sm text-left text-gray-500">
-            <thead className="border-y-[1.25px] border-[#d1d6db] text-xs uppercase bg-[#f2f4f6] text-center">
-              <tr className="h-[2rem]">
-                <th
-                  scope="col"
-                  className="font-medium text-[#333d4b] w-16 px-4 py-2 hover:bg-[#e6e8eb]"
-                >
-                  번호
-                </th>
-                <th
-                  scope="col"
-                  className="font-medium text-[#333d4b] px-4 py-2 hover:bg-[#e6e8eb]"
-                >
-                  제목
-                </th>
-                <th
-                  scope="col"
-                  className="font-medium text-[#333d4b] w-32 px-4 py-2 hover:bg-[#e6e8eb]"
-                >
-                  작성자
-                </th>
-                <th
-                  scope="col"
-                  className="font-medium text-[#333d4b] w-24 px-4 py-2 hover:bg-[#e6e8eb]"
-                >
-                  작성일
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {resData?.documents.length === 0 ? (
-                <EmptyNoticeListItem />
-              ) : (
-                <>
-                  {resData?.documents.map(
-                    (noticeInfo: NoticeInfo, index: number) => (
-                      <NoticeListItem
-                        noticeInfo={noticeInfo}
-                        total={resData.total}
-                        page={page}
-                        index={index}
-                        key={index}
-                      />
-                    ),
-                  )}
-                </>
-              )}
-            </tbody>
-          </table>
+          <div className="w-[60rem] 3xs:w-full text-sm text-left text-gray-500">
+            {resData?.documents.length === 0 ? (
+              <EmptyNoticeListItem />
+            ) : (
+              <>
+                {resData?.documents.map(
+                  (noticeInfo: NoticeInfo, index: number) => (
+                    <NoticeListItem
+                      noticeInfo={noticeInfo}
+                      total={resData.total}
+                      page={page}
+                      index={index}
+                      key={index}
+                    />
+                  ),
+                )}
+              </>
+            )}
+          </div>
         </div>
       </div>
 
-      <PaginationNav
-        page={page}
-        totalPages={totalPages}
-        handlePagination={handlePagination}
-      />
+      <div className="mt-10">
+        <PaginationNav
+          page={page}
+          totalPages={totalPages}
+          handlePagination={handlePagination}
+        />
+      </div>
     </div>
   );
 }

--- a/judger-frontend/app/notices/components/NoticeListItem.tsx
+++ b/judger-frontend/app/notices/components/NoticeListItem.tsx
@@ -1,5 +1,6 @@
 import { NoticeInfo } from '@/types/notice';
-import { formatDateToYYMMDD } from '@/utils/formatDate';
+import { formatDateToYYMMDDWithDot } from '@/utils/formatDate';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -13,26 +14,23 @@ interface NoticeListItemProps {
 export default function NoticeListItem(props: NoticeListItemProps) {
   const { noticeInfo, total, page, index } = props;
 
-  const router = useRouter();
+  const lastPage = Math.ceil(total / 10);
 
   return (
-    <tr
-      className="h-[2.5rem] border-b-[1.25px] border-[#d1d6db] text-xs text-center cursor-pointer hover:bg-[#e8f3ff]"
-      onClick={(e) => {
-        router.push(`/notices/${noticeInfo._id}`);
-      }}
+    <Link
+      href={`/notices/${noticeInfo._id}`}
+      className={`flex flex-col items-start gap-y-1 py-5 ${
+        ((lastPage > page && index + 1 !== 10) ||
+          (lastPage === page && index + 1 !== total % 10)) &&
+        'border-b-[0.5px] border-[#ededef]'
+      } text-center cursor-pointer`}
     >
-      <th
-        scope="row"
-        className="px-2 py-2 font-normal text-[#4e5968] whitespace-nowrap dark:text-white"
-      >
-        {total - (page - 1) * 10 - index}
-      </th>
-      <td className="px-2 font-semibold text-[#4e5968]">{noticeInfo.title}</td>
-      <td className="px-2 text-[#4e5968]">{noticeInfo.writer.name}</td>
-      <td className="px-2 text-[#4e5968]">
-        {formatDateToYYMMDD(noticeInfo.createdAt)}
-      </td>
-    </tr>
+      <span className="font-semibold text-[#4e5968] text-[18px]">
+        {noticeInfo.title}
+      </span>
+      <span className="text-[#8b95a1] text-[14px] font-extralight">
+        {formatDateToYYMMDDWithDot(noticeInfo.createdAt)}
+      </span>
+    </Link>
   );
 }

--- a/judger-frontend/app/notices/page.tsx
+++ b/judger-frontend/app/notices/page.tsx
@@ -27,55 +27,14 @@ export default function Notices() {
   }, [titleQuery, isInitialized]);
 
   return (
-    <div className="mt-2 px-5 2lg:px-0 overflow-x-auto">
+    <div className="mt-10 px-5 2lg:px-0 overflow-x-auto">
       <div className="flex flex-col w-[21rem] xs:w-[90%] xl:w-[60rem] mx-auto">
-        <p className="h-16 flex items-center text-[32px] font-semibold tracking-wide">
+        <p className="h-16 flex items-center text-[42px] font-bold tracking-wide">
           <span className="lift-up">공지사항</span>
         </p>
 
-        <div className="mt-5 mb-4">
-          <div className="flex flex-col 3md:flex-row justify-between gap-2 items-start">
-            <div className="w-full 3md:w-1/2 h-[2.3rem] flex items-center pl-3 pr-1 outline outline-1 outline-[#e6e8ea] rounded-md hover:outline-[#93bcfa] hover:outline-2 focus-within:outline-[#93bcfa] focus-within:outline-2">
-              <svg
-                fill="none"
-                width="21"
-                height="21"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="m19.59 18.41-3.205-3.203c1.0712-1.3712 1.579-3.0994 1.4197-4.832-.1593-1.73274-.9735-3.3394-2.2767-4.49233s-2.9972-1.76527-4.7364-1.71212c-1.73913.05315-3.39252.76779-4.62288 1.99815s-1.945 2.88375-1.99815 4.6229c-.05316 1.7392.55918 3.4332 1.71211 4.7364s2.7596 2.1174 4.49232 2.2767c1.7327.1592 3.4608-.3485 4.832-1.4197l3.204 3.204c.1567.1541.3678.24.5876.2391.2197-.0009.4302-.0886.5856-.2439.1554-.1554.243-.3659.2439-.5856.001-.2198-.085-.431-.2391-.5876zm-4.886-3.808c-.0183.0156-.036.032-.053.049-.042.044-.042.044-.08.092-.91.886-2.197 1.424-3.571 1.424-1.19232.0001-2.348-.4121-3.27107-1.1668s-1.55672-1.8055-1.79352-2.974c-.2368-1.1686-.06217-2.38311.49428-3.43762s1.46047-1.88413 2.55878-2.34819c1.09833-.46405 2.32333-.53398 3.46733-.19793s2.1365 1.0574 2.8094 2.04174c.6728.98434.9845 2.1711.8822 3.359-.1022 1.1879-.6122 2.3039-1.4434 3.1588z"
-                  fill="#8994a2"
-                ></path>
-              </svg>
-              <div className="w-full">
-                <input
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full h-[2.3rem] pl-[0.625rem] pr-[0.25rem] outline-none placeholder-[#888e96] text-[0.825rem] font-extralight"
-                  placeholder="제목, 작성자명으로 검색"
-                />
-              </div>
-              {searchQuery && (
-                <button
-                  onClick={(e) => {
-                    setSearchQuery('');
-                  }}
-                  className="p-1"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    height="25"
-                    viewBox="0 -960 960 960"
-                    width="25"
-                    fill="#a2a4a9"
-                  >
-                    <path d="M480-437.847 277.076-234.924q-8.307 8.308-20.884 8.5-12.576.193-21.268-8.5-8.693-8.692-8.693-21.076t8.693-21.076L437.847-480 234.924-682.924q-8.308-8.307-8.5-20.884-.193-12.576 8.5-21.268 8.692-8.693 21.076-8.693t21.076 8.693L480-522.153l202.924-202.923q8.307-8.308 20.884-8.5 12.576-.193 21.268 8.5 8.693 8.692 8.693 21.076t-8.693 21.076L522.153-480l202.923 202.924q8.308 8.307 8.5 20.884.193 12.576-8.5 21.268-8.692 8.693-21.076 8.693t-21.076-8.693L480-437.847Z"></path>
-                  </svg>
-                </button>
-              )}
-            </div>
-
+        <div className="mt-6">
+          <div className="flex flex-col 3md:flex-row justify-end gap-2 items-start">
             {OPERATOR_ROLES.includes(userInfo.role) && (
               <div className="w-full 3md:w-fit mt-2 3md:mt-0 flex gap-2">
                 <Link

--- a/judger-frontend/utils/formatDate.ts
+++ b/judger-frontend/utils/formatDate.ts
@@ -55,6 +55,19 @@ export function formatDateToYYMMDD(dateString: string): string {
   return `${year}/${month}/${day}`;
 }
 
+export function formatDateToYYMMDDWithDot(dateString: string): string {
+  // Date 객체 생성
+  const date = new Date(dateString);
+
+  // 연도, 월, 일을 추출
+  const year = date.getFullYear().toString(); // 연도의 마지막 두 자리
+  const month = (date.getMonth() + 1).toString().padStart(2, '0'); // getMonth()는 0부터 시작하므로 1을 더함
+  const day = date.getDate().toString().padStart(2, '0');
+
+  // 'YY/MM/DD' 형식으로 문자열 구성
+  return `${year}. ${month}. ${day}`;
+}
+
 export interface TimeDifference {
   isPast: boolean;
   days: number;


### PR DESCRIPTION
resolve #102 

## Description

공지사항 페이지에서 사용되던 UI가 서비스 내 `대회` 및 `시험` 목록 페이지와 유사하여
독립적으로 관리되는 페이지임을 강조할 수 있도록 다른 스타일로 변경하고자 하였습니다.

- 수정 전, 공지사항 페이지 UI

<img width="1131" alt="Screenshot 2025-02-02 at 9 07 40 PM" src="https://github.com/user-attachments/assets/fe20022c-c7a0-4aa2-9eb7-727e2ccd0577" />

<img width="1131" alt="Screenshot 2025-02-02 at 9 19 41 PM" src="https://github.com/user-attachments/assets/4e160ddc-b721-45c0-972d-fea033c8c816" />

- 수정 후, 공지사항 페이지 UI

<img width="1131" alt="Screenshot 2025-02-02 at 9 07 45 PM" src="https://github.com/user-attachments/assets/25960897-cfbe-460b-8149-881be3d43e29" />

<img width="1131" alt="Screenshot 2025-02-02 at 9 19 49 PM" src="https://github.com/user-attachments/assets/1d07c1f7-6b1e-4d79-9199-9b721c5475eb" />
